### PR TITLE
Multilib support

### DIFF
--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -67,6 +67,21 @@
                         "url-template": "https://static.rust-lang.org/dist/rust-$version-x86_64-unknown-linux-gnu.tar.gz"
                     },
                     "size": 258961351
+                },
+                {
+                    "type": "archive",
+                    "only-arches": [
+                        "i386"
+                    ],
+                    "url": "https://static.rust-lang.org/dist/rust-1.47.0-i686-unknown-linux-gnu.tar.gz",
+                    "sha256": "84bf092130ea5216fc701871e633563fc1c01b6528f60cb0767e96cd8eec30bf",
+                    "x-checker-data": {
+                        "type": "html",
+                        "url": "https://www.rust-lang.org/",
+                        "version-pattern": "Version ((?:\\d+\\.)?(?:\\d+\\.)?\\d+)",
+                        "url-template": "https://static.rust-lang.org/dist/rust-$version-i686-unknown-linux-gnu.tar.gz"
+                    },
+                    "size": 260725750
                 }
             ],
             "build-commands": [

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -26,8 +26,9 @@
                 {
                     "type": "archive",
                     "only-arches": [
-                        "arm"
+                        "arm", "aarch64"
                     ],
+                    "dest": "rust-armv7-unknown-linux-gnueabihf",
                     "url": "https://static.rust-lang.org/dist/rust-1.47.0-armv7-unknown-linux-gnueabihf.tar.gz",
                     "sha256": "19d0fe3892a8e98f99c5aa84f4d6f260853147650cb71f2bae985c91de6c29af",
                     "x-checker-data": {
@@ -43,6 +44,7 @@
                     "only-arches": [
                         "aarch64"
                     ],
+                    "dest": "rust-aarch64-unknown-linux-gnu",
                     "url": "https://static.rust-lang.org/dist/rust-1.47.0-aarch64-unknown-linux-gnu.tar.gz",
                     "sha256": "753c905e89a714ab9bce6fe1397b721f29c0760c32f09d2f328af3d39919c8e6",
                     "x-checker-data": {
@@ -58,6 +60,7 @@
                     "only-arches": [
                         "x86_64"
                     ],
+                    "dest": "rust-x86_64-unknown-linux-gnu",
                     "url": "https://static.rust-lang.org/dist/rust-1.47.0-x86_64-unknown-linux-gnu.tar.gz",
                     "sha256": "d0e11e1756a072e8e246b05d54593402813d047d12e44df281fbabda91035d96",
                     "x-checker-data": {
@@ -71,8 +74,9 @@
                 {
                     "type": "archive",
                     "only-arches": [
-                        "i386"
+                        "i386", "x86_64"
                     ],
+                    "dest": "rust-i686-unknown-linux-gnu",
                     "url": "https://static.rust-lang.org/dist/rust-1.47.0-i686-unknown-linux-gnu.tar.gz",
                     "sha256": "84bf092130ea5216fc701871e633563fc1c01b6528f60cb0767e96cd8eec30bf",
                     "x-checker-data": {
@@ -84,8 +88,37 @@
                     "size": 260725750
                 }
             ],
+            "build-options": {
+                "arch": {
+                    "x86_64": {
+                        "env": {
+                            "NATIVE_TARGET": "x86_64-unknown-linux-gnu",
+                            "COMPAT_TARGET": "i686-unknown-linux-gnu"
+                        }
+                    },
+                    "i386": {
+                        "env": {
+                            "NATIVE_TARGET": "i686-unknown-linux-gnu",
+                            "COMPAT_TARGET": ""
+                        }
+                    },
+                    "aarch64": {
+                        "env": {
+                            "NATIVE_TARGET": "aarch64-unknown-linux-gnu",
+                            "COMPAT_TARGET": "armv7-unknown-linux-gnueabihf"
+                        }
+                    },
+                    "arm": {
+                        "env": {
+                            "NATIVE_TARGET": "armv7-unknown-linux-gnueabihf",
+                            "COMPAT_TARGET": ""
+                        }
+                    }
+                }
+            },
             "build-commands": [
-                "./install.sh --prefix=/usr/lib/sdk/rust-stable --disable-ldconfig --verbose"
+                "cd \"rust-$NATIVE_TARGET\" && ./install.sh --prefix=/usr/lib/sdk/rust-stable --disable-ldconfig --verbose",
+                "test -n \"$COMPAT_TARGET\" && cd \"rust-$COMPAT_TARGET\" && ./install.sh --prefix=/usr/lib/sdk/rust-stable --disable-ldconfig --verbose --components=rust-std-$COMPAT_TARGET,rust-analysis-$COMPAT_TARGET"
             ]
         },
         {


### PR DESCRIPTION
Install i686 and armv7 rust-std and rust-analysis for x86_64 and aarch64 respectively.

Fixes #19 

Since GCC in FD.o SDK is built without multilib support and cross-compiller is to be used instead, a `.cargo/config.toml` like this is required to build for foreign architecture:
```toml
[target.i686-unknown-linux-gnu]
linker = "i686-unknown-linux-gnu-gcc"
ar = "i686-unknown-linux-gnu-ar"
```