### PR TITLE
Adds the (fast) mold linker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.flatpak-builder

--- a/README.md
+++ b/README.md
@@ -15,3 +15,6 @@ In order to use the (fast) [mold](https://github.com/rui314/mold) linker:
 linker = "clang"
 rustflags = ["-C", "link-arg=-fuse-ld=/usr/lib/sdk/rust-stable/bin/mold"]
 ```
+
+Note: llvm12 is needed until there is a release of gcc12.1.
+As soon as gcc12.1 is in the freedesktop sdk, gcc can be used instead of clang.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This extension contains various components of the [Rust](https://www.rust-lang.o
 
 In order to use the (fast) [mold](https://github.com/rui314/mold) linker:
 
-1. Add "org.freedesktop.Sdk.Extension.llvm12" next to this extension in order to get clang
+1. Add "org.freedesktop.Sdk.Extension.llvm13" next to this extension in order to get clang
 2. Add `.cargo/config.toml` with the following content
 
 ```toml
@@ -16,5 +16,5 @@ linker = "clang"
 rustflags = ["-C", "link-arg=-fuse-ld=/usr/lib/sdk/rust-stable/bin/mold"]
 ```
 
-Note: llvm12 is needed until there is a release of gcc12.1.
+Note: llvm13 is needed until there is a release of gcc12.1.
 As soon as gcc12.1 is in the freedesktop sdk, gcc can be used instead of clang.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# SDK Extension for Rust stable
+
+This extension contains various components of the [Rust](https://www.rust-lang.org) stable toolchain.
+
+
+## Mold
+
+In order to use the (fast) [mold](https://github.com/rui314/mold) linker:
+
+1. Add "org.freedesktop.Sdk.Extension.llvm12" next to this extension in order to get clang
+2. Add `.cargo/config.toml` with the following content
+
+```toml
+[target.x86_64-unknown-linux-gnu]
+linker = "clang"
+rustflags = ["-C", "link-arg=-fuse-ld=/usr/lib/sdk/rust-stable/bin/mold"]
+```

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -174,7 +174,7 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.2/mold-1.2.0-x86_64-linux.tar.gz",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.2.0/mold-1.2.0-x86_64-linux.tar.gz",
                     "sha256": "e818703859ce867bb4f57f4f9eed9da427d012bf4bc7a350e27f0d0039dab11f",
                     "x-checker-data": {
                         "type": "anitya",
@@ -189,7 +189,7 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.2/mold-1.2.0-aarch64-linux.tar.gz",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.2.0/mold-1.2.0-aarch64-linux.tar.gz",
                     "sha256": "da97071358261cb9c3f6f058879119a544f91a5f692c0042546f30824d2f5ab2",
                     "x-checker-data": {
                         "type": "anitya",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -166,6 +166,45 @@
             ]
         },
         {
+            "name": "mold",
+            "sources": [
+                {
+                    "type": "archive",
+                    "dest-filename": "mold-linux.tar.gz",
+                    "only-arches": [
+                        "x86_64"
+                    ],
+                    "url": "https://github.com/rui314/mold/releases/download/v1.2/mold-1.2.0-x86_64-linux.tar.gz",
+                    "sha256": "e818703859ce867bb4f57f4f9eed9da427d012bf4bc7a350e27f0d0039dab11f",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 241732,
+                        "stable-only": true,
+                        "url-template": "https://github.com/rui314/mold/releases/download/v1.2/mold-$version-x86_64-linux.tar.gz"
+                    }
+                },
+                {
+                    "type": "archive",
+                    "dest-filename": "mold-linux.tar.gz",
+                    "only-arches": [
+                        "aarch64"
+                    ],
+                    "url": "https://github.com/rui314/mold/releases/download/v1.2/mold-1.2.0-aarch64-linux.tar.gz",
+                    "sha256": "da97071358261cb9c3f6f058879119a544f91a5f692c0042546f30824d2f5ab2",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 241732,
+                        "stable-only": true,
+                        "url-template": "https://github.com/rui314/mold/releases/download/v1.2/mold-$version-aarch64-linux.tar.gz"
+                    }
+                }
+            ],
+            "buildsystem": "simple",
+            "build-commands": [
+                "install -m 755 bin/mold /usr/lib/sdk/rust-stable/bin/mold"
+            ]
+        },
+        {
             "name": "scripts",
             "sources": [
                 {


### PR DESCRIPTION
In order to use it in a flatpak:

1. "org.freedesktop.Sdk.Extension.llvm12" has to be added next to this extension (for clang)
2. `.cargo/config.toml` with the following content has to be addedd

```toml
[target.x86_64-unknown-linux-gnu]
linker = "clang"
rustflags = ["-C", "link-arg=-fuse-ld=/usr/lib/sdk/rust-stable/bin/mold"]
```
