### PR TITLE
Fix mold instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,10 @@ rustflags = ["-C", "link-arg=-fuse-ld=/usr/lib/sdk/rust-stable/bin/mold"]
 
 Note: llvm13 is needed until there is a release of gcc12.1.
 As soon as gcc12.1 is in the freedesktop sdk, gcc can be used instead of clang.
+
+## Debugging/Development
+
+In order to use this extension in flatpak SDK environment you may add all provided tools in your PATH by executing first:
+```
+source /usr/lib/sdk/rust-stable/enable.sh
+```

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ This extension contains various components of the [Rust](https://www.rust-lang.o
 
 In order to use the (fast) [mold](https://github.com/rui314/mold) linker:
 
-1. Add `org.freedesktop.Sdk.Extension.llvm13` allong with this extension in order to get clang.
-2. Add `/usr/lib/sdk/llvm13/lib` in `append-ld-library-path` and `append-path`. See [llvm13 SDK extension readme](https://github.com/flathub/org.freedesktop.Sdk.Extension.llvm13) for more information.
-3. Add `config.toml` with the following content in `CARGO_HOME` directory:
+1. Add `org.freedesktop.Sdk.Extension.llvm13` along with this extension in order to get clang.
+2. Add `/usr/lib/sdk/llvm13/bin` to `append-path`. See [llvm13 SDK extension readme](https://github.com/flathub/org.freedesktop.Sdk.Extension.llvm13) for more information.
+3. Add `.cargo/config.toml` in the root of the repository with the following content:
 
 ```toml
 [target.x86_64-unknown-linux-gnu]
@@ -18,4 +18,4 @@ rustflags = ["-C", "link-arg=-fuse-ld=/usr/lib/sdk/rust-stable/bin/mold"]
 ```
 
 Note: llvm13 is needed until there is a release of gcc12.1.
-As soon as gcc12.1 is in the freedesktop sdk, gcc can be used instead of clang. Additionally, step 1 and 2 can be skipped.
+As soon as gcc12.1 is in the freedesktop sdk, gcc can be used instead of clang.


### PR DESCRIPTION
- `bin` has to be appended to PATH not lib
- `lib` is not necessary at all
- Remove the `CARGO_HOME` part.
- Remove the last sentence. Let's just rewrite the instructions when gcc12.1 is out.


@SeaDve I tested it again, and as expected all you need to do is add `bin` to `PATH` to get clang.
Not sure what problems you encountered there.
Also why did you specify `CARGO_HOME` there?

CC: @bilelmoussaoui 