### PR TITLE
Add sccache

### DIFF
--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -205,6 +205,45 @@
             ]
         },
         {
+            "name": "sccache",
+            "sources": [
+                {
+                    "type": "archive",
+                    "dest-filename": "sccache-linux.tar.gz",
+                    "only-arches": [
+                        "x86_64"
+                    ],
+                    "url": "https://github.com/mozilla/sccache/releases/download/v0.3.0/sccache-v0.3.0-x86_64-unknown-linux-musl.tar.gz",
+                    "sha256": "e6cd8485f93d683a49c83796b9986f090901765aa4feb40d191b03ea770311d8",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 227267,
+                        "stable-only": true,
+                        "url-template": "https://github.com/mozilla/sccache/releases/download/v$version/sccache-v$version-x86_64-unknown-linux-musl.tar.gz"
+                    }
+                },
+                {
+                    "type": "archive",
+                    "dest-filename": "sccache-linux.tar.gz",
+                    "only-arches": [
+                        "aarch64"
+                    ],
+                    "url": "https://github.com/mozilla/sccache/releases/download/v0.3.0/sccache-v0.3.0-aarch64-unknown-linux-musl.tar.gz",
+                    "sha256": "9ae4e1056b3d51546fa42a4cbf8e95aa84a4b2b4c838f9114e01b7fef5c0abd0",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 227267,
+                        "stable-only": true,
+                        "url-template": "https://github.com/mozilla/sccache/releases/download/v$version/sccache-v$version-aarch64-unknown-linux-musl.tar.gz"
+                    }
+                }
+            ],
+            "buildsystem": "simple",
+            "build-commands": [
+                "install -m 755 sccache /usr/lib/sdk/rust-stable/bin/sccache"
+            ]
+        },
+        {
             "name": "scripts",
             "sources": [
                 {


### PR DESCRIPTION
While Flatpak Builder doesn't make it easy, it's possible to take advantage of sccache for local builds with local storage cache, but still have the packaging work correctly with Flathub CI.

1. Move your sccache local cache folder under your ccache folder. Flatpak Builder already mounts the ccache folder onto `/run/ccache`, so our sccache folder will also be accessible.
2. Move your sccache config into the sccache cache folder. The main setting you might want to have is the cache storage size.
```
# https://github.com/mozilla/sccache/blob/main/docs/Configuration.md
[cache.disk]
size = 3221225472 # 3GiB
```
3. You should symlink `$XDG_CACHE_HOME/sccache -> $CCACHE_DIR/sccache` to not break this for the host, or update the relevant environment variables.
4. Add these environment variables to your packaging manifest.
```
build-options:
  env:
    - SCCACHE_DIR=/run/ccache/sccache
    - SCCACHE_CONF=/run/ccache/sccache/config
```
5. Add this module as the first one in your packaging manifest. Currently, a symlink doesn't work, so we need to copy the binary.
```
  - name: sccache
    buildsystem: simple
    build-commands:
      - |
        if [ "$CCACHE_DIR" == "/run/ccache" ]; then
          install -Dm755 /usr/lib/sdk/rust-stable/bin/sccache ${FLATPAK_DEST}/bin/rustc
        fi
    cleanup:
      - '*'
```