### PR TITLE
21.08 1.67

### DIFF
--- a/org.freedesktop.Sdk.Extension.rust-stable.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.rust-stable.appdata.xml
@@ -12,6 +12,7 @@
   <translation/>
   <update_contact>danigm@gnome.org</update_contact>
   <releases>
+    <release version="1.64.0" date="2022-09-22"/>
     <release version="1.63.0" date="2022-08-11"/>
     <release version="1.60.0" date="2022-04-07"/>
     <release version="1.59.0" date="2022-02-24"/>

--- a/org.freedesktop.Sdk.Extension.rust-stable.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.rust-stable.appdata.xml
@@ -12,6 +12,7 @@
   <translation/>
   <update_contact>danigm@gnome.org</update_contact>
   <releases>
+    <release version="1.66.0" date="2022-12-15"/>
     <release version="1.65.0" date="2022-11-03"/>
     <release version="1.64.0" date="2022-09-22"/>
     <release version="1.63.0" date="2022-08-11"/>

--- a/org.freedesktop.Sdk.Extension.rust-stable.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.rust-stable.appdata.xml
@@ -12,6 +12,7 @@
   <translation/>
   <update_contact>danigm@gnome.org</update_contact>
   <releases>
+    <release version="1.66.1" date="2023-01-10"/>
     <release version="1.66.0" date="2022-12-15"/>
     <release version="1.65.0" date="2022-11-03"/>
     <release version="1.64.0" date="2022-09-22"/>

--- a/org.freedesktop.Sdk.Extension.rust-stable.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.rust-stable.appdata.xml
@@ -12,6 +12,7 @@
   <translation/>
   <update_contact>danigm@gnome.org</update_contact>
   <releases>
+    <release version="1.67.0" date="2023-01-26"/>
     <release version="1.66.1" date="2023-01-10"/>
     <release version="1.66.0" date="2022-12-15"/>
     <release version="1.65.0" date="2022-11-03"/>

--- a/org.freedesktop.Sdk.Extension.rust-stable.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.rust-stable.appdata.xml
@@ -12,6 +12,7 @@
   <translation/>
   <update_contact>danigm@gnome.org</update_contact>
   <releases>
+    <release version="1.63.0" date="2022-08-11"/>
     <release version="1.60.0" date="2022-04-07"/>
     <release version="1.59.0" date="2022-02-24"/>
     <release version="1.58.1" date="2022-01-20"/>

--- a/org.freedesktop.Sdk.Extension.rust-stable.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.rust-stable.appdata.xml
@@ -12,6 +12,7 @@
   <translation/>
   <update_contact>danigm@gnome.org</update_contact>
   <releases>
+    <release version="1.65.0" date="2022-11-03"/>
     <release version="1.64.0" date="2022-09-22"/>
     <release version="1.63.0" date="2022-08-11"/>
     <release version="1.60.0" date="2022-04-07"/>

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-11-28/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "fe2433498eab3c4b49ce1c82f6eb66c9bb5218a3851b85ad61fc5724f82e7f4e",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-12-05/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "66d03c887981fd9d375c263f3831ceb34d4cd6b54bdcaf15c770a0f86237670b",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-11-28/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "748da2c68e16ad20dcba3b7c94a7ac348fabcaf92ca457a2f7125ca2a82c495c",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-12-05/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "6901271ac5cdcb82393cf0c0e142ddcce6e200196f0d33f340991cce8c335591",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -135,7 +135,7 @@
                         "x86_64"
                     ],
                     "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-01-09/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "2d6baf57929d677c895f0703d8401fe251b2b1cf929d02729160de35e4c71d6f",
+                    "sha256": "32e84be6bab29c9dc194754e9a58a0d1ff118b9ddd835fa64e02d8960a83bcd8",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-01-23/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "8b4d9de99f12273d4555e773c2fb76b0a5b5f1b3e44e6ecc415ec99417b94a0d",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-01-30/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "ca1fbd67a5efd558abebe8559264f8b1bd4f420647b844bc3bd247fa0f5d549e",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-01-23/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "95d584bd19145541079487f7a0b7be46294bd1668e6039a70241e2961a7804c5",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-01-30/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "1fcb29c29be15cb17a38a83693a957bb8e704421e5a0b97599521402019b86bc",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-10-10/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "38535e9231285123e1dfa838908e61624f0f5dd8cb58e255408b30ea19a3a6eb",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-10-17/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "323cad202e161c4e4b9bc7669552fd9c6e55b2368cccf2c0d61ef86e8caf7dc9",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-10-10/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "1afb87401b3dfa63bad9f2041e87849975ec1af2fbdf780792a8b587295e2c33",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-10-17/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "d4c5c1a6df116a27f548ed17ffb57594f97713cde323c932cf7ba9d88dc9c21a",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -180,7 +180,7 @@
                         "type": "anitya",
                         "project-id": 241732,
                         "stable-only": true,
-                        "url-template": "https://github.com/rui314/mold/releases/download/v1.2/mold-$version-x86_64-linux.tar.gz"
+                        "url-template": "https://github.com/rui314/mold/releases/download/v$version/mold-$version-x86_64-linux.tar.gz"
                     }
                 },
                 {
@@ -195,7 +195,7 @@
                         "type": "anitya",
                         "project-id": 241732,
                         "stable-only": true,
-                        "url-template": "https://github.com/rui314/mold/releases/download/v1.2/mold-$version-aarch64-linux.tar.gz"
+                        "url-template": "https://github.com/rui314/mold/releases/download/v$version/mold-$version-aarch64-linux.tar.gz"
                     }
                 }
             ],

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-11-14/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "540dbcd6e9840105c70ed1d629c2e5822dc494c7387c7db51f1e5704b75c5d23",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-11-21/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "4ebdf56a65686acc79f0261d20bf7392afb477a53454f247397ec1ae8d70d9ba",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-11-14/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "0f40bcd2527314e1332c45a96cff3c7f06f8e2b5f6e5e388bc307bbc64555c0e",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-11-21/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "d13aceae777d1565987fcc28d0dff3f790dd2774a6ac0964b522624a1778a3d9",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -1,10 +1,10 @@
 {
     "id": "org.freedesktop.Sdk.Extension.rust-stable",
-    "branch": "22.08beta",
+    "branch": "22.08",
     "runtime": "org.freedesktop.Sdk",
     "build-extension": true,
     "sdk": "org.freedesktop.Sdk",
-    "runtime-version": "22.08beta",
+    "runtime-version": "22.08",
     "sdk-extensions": [],
     "separate-locales": false,
     "appstream-compose": false,

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-09-26/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "1a92fa7cfa20611087924fb32b5c722a8076d82ada73943909c259d1a9360a72",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-10-03/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "b48013f713199533d4dff970ed24273563a5543579057a0a571bfe87b44ca2fd",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-09-26/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "59027b0e38b3e091419e70538dafffd03265b9d5b76c1255c3f119660af8ffbf",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-10-03/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "1aad3db25f6e0c43c15d284fb68b3a893ab01585412af914db3eb96fe102e4be",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-10-31/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "b4c8d190a83bd386de73a38b987ca13a92651fc1ad47ccbd20c8ad4fcb2b02c1",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-11-07/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "319b445878208c6eb02a0c6167c7591bc2ed64fe018d9d962e24567ba1f11fab",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-10-31/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "177ae838352164fd007eddfe2f89e1ee651ac9e9bc7df5a491179aa30dba2918",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-11-07/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "a584dd5682d3ffb10c59b1421cddd8a74e7bc2372aea492c4a383e2bad4389fa",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -174,8 +174,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.8.0/mold-1.8.0-x86_64-linux.tar.gz",
-                    "sha256": "308b8a3c8a44e232348a13764f581538ec80c28c420167fd6dad3d64c05e17c2",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.9.0/mold-1.9.0-x86_64-linux.tar.gz",
+                    "sha256": "e534e7a6e2fa88e749bd4579d1bfe6397fad2393bae8450c18aba339ac567a9f",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 241732,
@@ -189,8 +189,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.8.0/mold-1.8.0-aarch64-linux.tar.gz",
-                    "sha256": "b9464df5f3dd36e17f473173afcd853f1cc2c357e52ec2b896950283c2a2adfd",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.9.0/mold-1.9.0-aarch64-linux.tar.gz",
+                    "sha256": "826d6599ffc8a03fa5858325d2a9b8866c6a38e3bb45a0c4d84784d5482b756c",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 241732,

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-10-03/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "b48013f713199533d4dff970ed24273563a5543579057a0a571bfe87b44ca2fd",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-10-10/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "38535e9231285123e1dfa838908e61624f0f5dd8cb58e255408b30ea19a3a6eb",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-10-03/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "1aad3db25f6e0c43c15d284fb68b3a893ab01585412af914db3eb96fe102e4be",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-10-10/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "1afb87401b3dfa63bad9f2041e87849975ec1af2fbdf780792a8b587295e2c33",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -27,8 +27,8 @@
                         "aarch64"
                     ],
                     "dest": "rust-armv7-unknown-linux-gnueabihf",
-                    "url": "https://static.rust-lang.org/dist/2022-11-03/rust-1.65.0-armv7-unknown-linux-gnueabihf.tar.xz",
-                    "sha256": "c34e277f6883e0038633175b55d0af858a1f8d329c65d83fa00d125edb063352",
+                    "url": "https://static.rust-lang.org/dist/2022-12-15/rust-1.66.0-armv7-unknown-linux-gnueabihf.tar.xz",
+                    "sha256": "6e3f65eb819956624569b5fed56f49e808e1fd5845bcb696c4fd36d0ab923617",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -41,8 +41,8 @@
                         "aarch64"
                     ],
                     "dest": "rust-aarch64-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2022-11-03/rust-1.65.0-aarch64-unknown-linux-gnu.tar.xz",
-                    "sha256": "b3a83a9585b8c4ede4eab2a11b3f96895f676d8b46c9642140c4fefd5c309ed1",
+                    "url": "https://static.rust-lang.org/dist/2022-12-15/rust-1.66.0-aarch64-unknown-linux-gnu.tar.xz",
+                    "sha256": "e8d853383355aa17fd8d7efae740ac0f18b3a5f452c9ac62f5042fc96ebda3e9",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -55,8 +55,8 @@
                         "x86_64"
                     ],
                     "dest": "rust-x86_64-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2022-11-03/rust-1.65.0-x86_64-unknown-linux-gnu.tar.xz",
-                    "sha256": "9455cab767f7b9f46259aac8d953f15f11b3d65513384e2b0a5e77d0432ae82f",
+                    "url": "https://static.rust-lang.org/dist/2022-12-15/rust-1.66.0-x86_64-unknown-linux-gnu.tar.xz",
+                    "sha256": "a656328e1cd36b253bf39807b5a3eacdf0ce7d982fc9fb51a026f273386de84a",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -71,8 +71,8 @@
                         "x86_64"
                     ],
                     "dest": "rust-i686-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2022-11-03/rust-1.65.0-i686-unknown-linux-gnu.tar.xz",
-                    "sha256": "50595b96f98e0940bbfe00209d6c233e9158e140ecd6088ad3bd53f89b123e9d",
+                    "url": "https://static.rust-lang.org/dist/2022-12-15/rust-1.66.0-i686-unknown-linux-gnu.tar.xz",
+                    "sha256": "c9551f9650fcaf74ea4fb6874b6853f9ffecb6925e7a087afb4f36840e5b7b8d",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -82,8 +82,8 @@
                 {
                     "type": "archive",
                     "dest": "rust-src",
-                    "url": "https://static.rust-lang.org/dist/2022-11-03/rust-src-1.65.0.tar.xz",
-                    "sha256": "7dfdbecad68d9fbc64574eb403aa4815adef563dd6fb1d8a1be3b9fff364deb2",
+                    "url": "https://static.rust-lang.org/dist/2022-12-15/rust-src-1.66.0.tar.xz",
+                    "sha256": "782d392e8401518a75914a39b958be0a210b254d5d39127839739f5d4d51a2eb",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust-src",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-01-16/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "1a08c6cbf51cb0897c4d2033e81ddd9ecc69201a2c27830ea310ce67c021b4da",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-01-23/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "8b4d9de99f12273d4555e773c2fb76b0a5b5f1b3e44e6ecc415ec99417b94a0d",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-01-16/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "d03a9ffb4c88e5bbf634ef656b2464754103fe7b0983a191671046973d463dfc",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-01-23/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "95d584bd19145541079487f7a0b7be46294bd1668e6039a70241e2961a7804c5",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -174,8 +174,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.9.0/mold-1.9.0-x86_64-linux.tar.gz",
-                    "sha256": "e534e7a6e2fa88e749bd4579d1bfe6397fad2393bae8450c18aba339ac567a9f",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.10.0/mold-1.10.0-x86_64-linux.tar.gz",
+                    "sha256": "b1d97a63700a290b3ab4cbc8e1c705b36d7f148967648681f053bb8c319190a0",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 241732,
@@ -189,8 +189,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.9.0/mold-1.9.0-aarch64-linux.tar.gz",
-                    "sha256": "826d6599ffc8a03fa5858325d2a9b8866c6a38e3bb45a0c4d84784d5482b756c",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.10.0/mold-1.10.0-aarch64-linux.tar.gz",
+                    "sha256": "71698d4835a9fa2815d88f4d92e66657a53cc1b9006c7bc80e960eb292885279",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 241732,

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-10-24/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "7b5f8eaed7770a2e38564872cd92a9c23e24e170c123c39a84b09477130a2892",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-10-31/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "b4c8d190a83bd386de73a38b987ca13a92651fc1ad47ccbd20c8ad4fcb2b02c1",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-10-24/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "1e81ff975eab14cea247e9f77e88ecf44760789f49da46d1e9745fefc70893d8",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-10-31/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "177ae838352164fd007eddfe2f89e1ee651ac9e9bc7df5a491179aa30dba2918",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -174,8 +174,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.7.0/mold-1.7.0-x86_64-linux.tar.gz",
-                    "sha256": "113f0db9915054f558a4e41cf6dbc45b7fd45076a4064830112fac8f82091fd9",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.7.1/mold-1.7.1-x86_64-linux.tar.gz",
+                    "sha256": "66b38b8ab3143f23c1eaad598dd9055ce84f39729f92d63eddbd856a73d65784",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 241732,
@@ -189,8 +189,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.7.0/mold-1.7.0-aarch64-linux.tar.gz",
-                    "sha256": "bb6ec2ec25f2c4b03bb1e66b303673e2203431115e1b907da9a528c64b49e65f",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.7.1/mold-1.7.1-aarch64-linux.tar.gz",
+                    "sha256": "9c43875c00972c61196eac41fca297403ec24c36b9232d1a6aa1cb84ce40f829",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 241732,

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-01-09/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "32e84be6bab29c9dc194754e9a58a0d1ff118b9ddd835fa64e02d8960a83bcd8",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-01-16/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "1a08c6cbf51cb0897c4d2033e81ddd9ecc69201a2c27830ea310ce67c021b4da",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-01-09/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "ffe1e03b60feabc1b53d0f16ba29c80835f2a586a23d4c0d828bf03eb40fb0e4",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-01-16/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "d03a9ffb4c88e5bbf634ef656b2464754103fe7b0983a191671046973d463dfc",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -1,10 +1,10 @@
 {
     "id": "org.freedesktop.Sdk.Extension.rust-stable",
-    "branch": "21.08",
+    "branch": "22.08",
     "runtime": "org.freedesktop.Sdk",
     "build-extension": true,
     "sdk": "org.freedesktop.Sdk",
-    "runtime-version": "21.08",
+    "runtime-version": "22.08",
     "sdk-extensions": [],
     "separate-locales": false,
     "appstream-compose": false,

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -174,8 +174,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.5.1/mold-1.5.1-x86_64-linux.tar.gz",
-                    "sha256": "2b4006aa3935bd65e448e0d0f0e70fe57c4d9a12074435e69bc31b212fdaa160",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.6.0/mold-1.6.0-x86_64-linux.tar.gz",
+                    "sha256": "d43b2215018f1c2280fcd64c891c570754c0322e817d75a80f9cd149b077a930",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 241732,
@@ -189,8 +189,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.5.1/mold-1.5.1-aarch64-linux.tar.gz",
-                    "sha256": "d71e728a6e2d0b6f58536ddd97f8592552d060b0cb9920a23b7db79c11efb26b",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.6.0/mold-1.6.0-aarch64-linux.tar.gz",
+                    "sha256": "5897ac0289dce8bcd62b067900e19f29af118b1aa2f8ce7cbcc0ffb256a6c88a",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 241732,

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-12-05/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "66d03c887981fd9d375c263f3831ceb34d4cd6b54bdcaf15c770a0f86237670b",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-12-12/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "625b1282c41dd192c63b269a4455cb9e2305fa831dd7195ab81fd1fcadc28caf",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-12-05/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "6901271ac5cdcb82393cf0c0e142ddcce6e200196f0d33f340991cce8c335591",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-12-12/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "5d741017dfa47bce76141fd9e96f66c1e2d6969abeccb62855e4af3950df8678",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-09-12/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "7cffcc22557ede856096a3e4021b4f83176dd6b3ac4e222e330268707d98a3bd",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-09-19/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "5347c331c4d2d43f6791c44c0ee7f7e4a5852146304e487f64865a40a866f1e5",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-09-12/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "1b3857080b4d0d5c713540c802fdd166286480dea4efc67d9f135b56fd63995a",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-09-19/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "095d024a0351eaf26bcea931d1145cbd95ef934048235e2812fdedfc717c87a3",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -27,8 +27,8 @@
                         "aarch64"
                     ],
                     "dest": "rust-armv7-unknown-linux-gnueabihf",
-                    "url": "https://static.rust-lang.org/dist/2022-12-15/rust-1.66.0-armv7-unknown-linux-gnueabihf.tar.xz",
-                    "sha256": "6e3f65eb819956624569b5fed56f49e808e1fd5845bcb696c4fd36d0ab923617",
+                    "url": "https://static.rust-lang.org/dist/2023-01-10/rust-1.66.1-armv7-unknown-linux-gnueabihf.tar.xz",
+                    "sha256": "4aeff6472c44e5a8756b63c493dbb3820739dc80f5e9e62dd509f32cd5a724c8",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -41,8 +41,8 @@
                         "aarch64"
                     ],
                     "dest": "rust-aarch64-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2022-12-15/rust-1.66.0-aarch64-unknown-linux-gnu.tar.xz",
-                    "sha256": "e8d853383355aa17fd8d7efae740ac0f18b3a5f452c9ac62f5042fc96ebda3e9",
+                    "url": "https://static.rust-lang.org/dist/2023-01-10/rust-1.66.1-aarch64-unknown-linux-gnu.tar.xz",
+                    "sha256": "a1279760f91b3571733e0b0268128d143be2734916753900b5fe7b8ecc3c0900",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -55,8 +55,8 @@
                         "x86_64"
                     ],
                     "dest": "rust-x86_64-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2022-12-15/rust-1.66.0-x86_64-unknown-linux-gnu.tar.xz",
-                    "sha256": "a656328e1cd36b253bf39807b5a3eacdf0ce7d982fc9fb51a026f273386de84a",
+                    "url": "https://static.rust-lang.org/dist/2023-01-10/rust-1.66.1-x86_64-unknown-linux-gnu.tar.xz",
+                    "sha256": "a201aa4595ec8015662b7103b1409a4787c6d1f1d540bb68746633527d855858",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -71,8 +71,8 @@
                         "x86_64"
                     ],
                     "dest": "rust-i686-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2022-12-15/rust-1.66.0-i686-unknown-linux-gnu.tar.xz",
-                    "sha256": "c9551f9650fcaf74ea4fb6874b6853f9ffecb6925e7a087afb4f36840e5b7b8d",
+                    "url": "https://static.rust-lang.org/dist/2023-01-10/rust-1.66.1-i686-unknown-linux-gnu.tar.xz",
+                    "sha256": "835b4e1b4d396674f7866a83b9a4f44db16fd12f01a7eaed527282b3700a9b92",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -82,8 +82,8 @@
                 {
                     "type": "archive",
                     "dest": "rust-src",
-                    "url": "https://static.rust-lang.org/dist/2022-12-15/rust-src-1.66.0.tar.xz",
-                    "sha256": "782d392e8401518a75914a39b958be0a210b254d5d39127839739f5d4d51a2eb",
+                    "url": "https://static.rust-lang.org/dist/2023-01-10/rust-src-1.66.1.tar.xz",
+                    "sha256": "752aa6cb02db94dc246cdcef4186f4e1d1640b72a7954b9cda01f479a7d1ed76",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust-src",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-11-21/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "4ebdf56a65686acc79f0261d20bf7392afb477a53454f247397ec1ae8d70d9ba",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-11-28/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "fe2433498eab3c4b49ce1c82f6eb66c9bb5218a3851b85ad61fc5724f82e7f4e",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-11-21/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "d13aceae777d1565987fcc28d0dff3f790dd2774a6ac0964b522624a1778a3d9",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-11-28/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "748da2c68e16ad20dcba3b7c94a7ac348fabcaf92ca457a2f7125ca2a82c495c",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -174,8 +174,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.2.0/mold-1.2.0-x86_64-linux.tar.gz",
-                    "sha256": "e818703859ce867bb4f57f4f9eed9da427d012bf4bc7a350e27f0d0039dab11f",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.4.2/mold-1.4.2-x86_64-linux.tar.gz",
+                    "sha256": "584768879ef75e57c1a129ae159f9ef65bed565d510e09fc7d9d98bc58b3d534",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 241732,
@@ -189,8 +189,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.2.0/mold-1.2.0-aarch64-linux.tar.gz",
-                    "sha256": "da97071358261cb9c3f6f058879119a544f91a5f692c0042546f30824d2f5ab2",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.4.2/mold-1.4.2-aarch64-linux.tar.gz",
+                    "sha256": "04ae35bb1d2120c901ba7887b33808081252c9e8997c90ba6ace8152ffaf28d6",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 241732,

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -1,10 +1,10 @@
 {
     "id": "org.freedesktop.Sdk.Extension.rust-stable",
-    "branch": "22.08",
+    "branch": "22.08beta",
     "runtime": "org.freedesktop.Sdk",
     "build-extension": true,
     "sdk": "org.freedesktop.Sdk",
-    "runtime-version": "22.08",
+    "runtime-version": "22.08beta",
     "sdk-extensions": [],
     "separate-locales": false,
     "appstream-compose": false,

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -27,8 +27,8 @@
                         "aarch64"
                     ],
                     "dest": "rust-armv7-unknown-linux-gnueabihf",
-                    "url": "https://static.rust-lang.org/dist/2022-08-11/rust-1.63.0-armv7-unknown-linux-gnueabihf.tar.xz",
-                    "sha256": "81e9e3dc569047f2a26512609978a4e5d4c06a05a071d44a6d9aadb4d7cbc079",
+                    "url": "https://static.rust-lang.org/dist/2022-09-22/rust-1.64.0-armv7-unknown-linux-gnueabihf.tar.xz",
+                    "sha256": "cad59223ac104dfb3f1ede0efb59f7212f2186da06b5d408cdfaf4710e2b9637",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -41,8 +41,8 @@
                         "aarch64"
                     ],
                     "dest": "rust-aarch64-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2022-08-11/rust-1.63.0-aarch64-unknown-linux-gnu.tar.xz",
-                    "sha256": "963dd3c8b0b1ba970e8608b5bf457c24d5dc471d68f40e5cb62582fbd0461988",
+                    "url": "https://static.rust-lang.org/dist/2022-09-22/rust-1.64.0-aarch64-unknown-linux-gnu.tar.xz",
+                    "sha256": "9081928cced6fc650eaccb88f2ea154dc95c066957b234fa9c0cbe1770479f54",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -55,8 +55,8 @@
                         "x86_64"
                     ],
                     "dest": "rust-x86_64-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2022-08-11/rust-1.63.0-x86_64-unknown-linux-gnu.tar.xz",
-                    "sha256": "be9b25bcf1e564876762e653688e0b5df11fab53048ac18bf77761cf0a0cc465",
+                    "url": "https://static.rust-lang.org/dist/2022-09-22/rust-1.64.0-x86_64-unknown-linux-gnu.tar.xz",
+                    "sha256": "bd69e42f6cfe3ba96d781ad0b4095ddac4f0fc31c1af445018edf6f0aba543e4",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -71,8 +71,8 @@
                         "x86_64"
                     ],
                     "dest": "rust-i686-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2022-08-11/rust-1.63.0-i686-unknown-linux-gnu.tar.xz",
-                    "sha256": "17081489b7efeb3936ed9bee2d21deaa86d76c3fed9be9e582c4325ca6aafae8",
+                    "url": "https://static.rust-lang.org/dist/2022-09-22/rust-1.64.0-i686-unknown-linux-gnu.tar.xz",
+                    "sha256": "b22e0efcdff9bcb27aef82148f26a5d3d67da618da3e6e8c9402fe7fcdd8ca69",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -82,8 +82,8 @@
                 {
                     "type": "archive",
                     "dest": "rust-src",
-                    "url": "https://static.rust-lang.org/dist/2022-08-11/rust-src-1.63.0.tar.xz",
-                    "sha256": "d4f84d50ea61630df493db5cb1f71e7429f4118e7dbf6af5eb548910abac517d",
+                    "url": "https://static.rust-lang.org/dist/2022-09-22/rust-src-1.64.0.tar.xz",
+                    "sha256": "0d16b1af409123627a16b4101421efb5792a866e32d7a0d04781fd1169754938",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust-src",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -120,7 +120,7 @@
                 }
             },
             "build-commands": [
-                "cd \"rust-$NATIVE_TARGET\" && ./install.sh --prefix=/usr/lib/sdk/rust-stable --without=rust-docs --disable-ldconfig --verbose",
+                "cd \"rust-$NATIVE_TARGET\" && ./install.sh --prefix=/usr/lib/sdk/rust-stable --without=rust-docs --without=rust-docs-json-preview --disable-ldconfig --verbose",
                 "test -n \"$COMPAT_TARGET\" &&  cd \"rust-$COMPAT_TARGET\" && ./install.sh --prefix=/usr/lib/sdk/rust-stable --disable-ldconfig --verbose --components=rust-std-$COMPAT_TARGET,rust-analysis-$COMPAT_TARGET",
                 "cd rust-src && ./install.sh --prefix=/usr/lib/sdk/rust-stable --disable-ldconfig --verbose"
             ]

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -27,8 +27,8 @@
                         "aarch64"
                     ],
                     "dest": "rust-armv7-unknown-linux-gnueabihf",
-                    "url": "https://static.rust-lang.org/dist/2022-09-22/rust-1.64.0-armv7-unknown-linux-gnueabihf.tar.xz",
-                    "sha256": "cad59223ac104dfb3f1ede0efb59f7212f2186da06b5d408cdfaf4710e2b9637",
+                    "url": "https://static.rust-lang.org/dist/2022-11-03/rust-1.65.0-armv7-unknown-linux-gnueabihf.tar.xz",
+                    "sha256": "c34e277f6883e0038633175b55d0af858a1f8d329c65d83fa00d125edb063352",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -41,8 +41,8 @@
                         "aarch64"
                     ],
                     "dest": "rust-aarch64-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2022-09-22/rust-1.64.0-aarch64-unknown-linux-gnu.tar.xz",
-                    "sha256": "9081928cced6fc650eaccb88f2ea154dc95c066957b234fa9c0cbe1770479f54",
+                    "url": "https://static.rust-lang.org/dist/2022-11-03/rust-1.65.0-aarch64-unknown-linux-gnu.tar.xz",
+                    "sha256": "b3a83a9585b8c4ede4eab2a11b3f96895f676d8b46c9642140c4fefd5c309ed1",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -55,8 +55,8 @@
                         "x86_64"
                     ],
                     "dest": "rust-x86_64-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2022-09-22/rust-1.64.0-x86_64-unknown-linux-gnu.tar.xz",
-                    "sha256": "bd69e42f6cfe3ba96d781ad0b4095ddac4f0fc31c1af445018edf6f0aba543e4",
+                    "url": "https://static.rust-lang.org/dist/2022-11-03/rust-1.65.0-x86_64-unknown-linux-gnu.tar.xz",
+                    "sha256": "9455cab767f7b9f46259aac8d953f15f11b3d65513384e2b0a5e77d0432ae82f",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -71,8 +71,8 @@
                         "x86_64"
                     ],
                     "dest": "rust-i686-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2022-09-22/rust-1.64.0-i686-unknown-linux-gnu.tar.xz",
-                    "sha256": "b22e0efcdff9bcb27aef82148f26a5d3d67da618da3e6e8c9402fe7fcdd8ca69",
+                    "url": "https://static.rust-lang.org/dist/2022-11-03/rust-1.65.0-i686-unknown-linux-gnu.tar.xz",
+                    "sha256": "50595b96f98e0940bbfe00209d6c233e9158e140ecd6088ad3bd53f89b123e9d",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -82,8 +82,8 @@
                 {
                     "type": "archive",
                     "dest": "rust-src",
-                    "url": "https://static.rust-lang.org/dist/2022-09-22/rust-src-1.64.0.tar.xz",
-                    "sha256": "0d16b1af409123627a16b4101421efb5792a866e32d7a0d04781fd1169754938",
+                    "url": "https://static.rust-lang.org/dist/2022-11-03/rust-src-1.65.0.tar.xz",
+                    "sha256": "7dfdbecad68d9fbc64574eb403aa4815adef563dd6fb1d8a1be3b9fff364deb2",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust-src",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -27,8 +27,8 @@
                         "aarch64"
                     ],
                     "dest": "rust-armv7-unknown-linux-gnueabihf",
-                    "url": "https://static.rust-lang.org/dist/2022-04-07/rust-1.60.0-armv7-unknown-linux-gnueabihf.tar.xz",
-                    "sha256": "f3c372bbb8927be77913dc7f3d1b4bacfdd0776008d617280dd8d046fe37846c",
+                    "url": "https://static.rust-lang.org/dist/2022-08-11/rust-1.63.0-armv7-unknown-linux-gnueabihf.tar.xz",
+                    "sha256": "81e9e3dc569047f2a26512609978a4e5d4c06a05a071d44a6d9aadb4d7cbc079",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -41,8 +41,8 @@
                         "aarch64"
                     ],
                     "dest": "rust-aarch64-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2022-04-07/rust-1.60.0-aarch64-unknown-linux-gnu.tar.xz",
-                    "sha256": "5d18bc384273edbd8a4b6d18104685651fb42d5f07bdf518ef2ec3641269c95d",
+                    "url": "https://static.rust-lang.org/dist/2022-08-11/rust-1.63.0-aarch64-unknown-linux-gnu.tar.xz",
+                    "sha256": "963dd3c8b0b1ba970e8608b5bf457c24d5dc471d68f40e5cb62582fbd0461988",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -55,8 +55,8 @@
                         "x86_64"
                     ],
                     "dest": "rust-x86_64-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2022-04-07/rust-1.60.0-x86_64-unknown-linux-gnu.tar.xz",
-                    "sha256": "83c3fb8645379ec308192fa713df87044892639495722077e07aa779b310239e",
+                    "url": "https://static.rust-lang.org/dist/2022-08-11/rust-1.63.0-x86_64-unknown-linux-gnu.tar.xz",
+                    "sha256": "be9b25bcf1e564876762e653688e0b5df11fab53048ac18bf77761cf0a0cc465",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -71,8 +71,8 @@
                         "x86_64"
                     ],
                     "dest": "rust-i686-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2022-04-07/rust-1.60.0-i686-unknown-linux-gnu.tar.xz",
-                    "sha256": "94567ff691b46ef3dff64f3866445a278a17b20639e62cdc4b6fcd7aed86cec8",
+                    "url": "https://static.rust-lang.org/dist/2022-08-11/rust-1.63.0-i686-unknown-linux-gnu.tar.xz",
+                    "sha256": "17081489b7efeb3936ed9bee2d21deaa86d76c3fed9be9e582c4325ca6aafae8",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -82,8 +82,8 @@
                 {
                     "type": "archive",
                     "dest": "rust-src",
-                    "url": "https://static.rust-lang.org/dist/2022-04-07/rust-src-1.60.0.tar.xz",
-                    "sha256": "66a96ff728d1538b1313322a754bf5b50bbfd0c3c75c6a5504c9e906918cbcb1",
+                    "url": "https://static.rust-lang.org/dist/2022-08-11/rust-src-1.63.0.tar.xz",
+                    "sha256": "d4f84d50ea61630df493db5cb1f71e7429f4118e7dbf6af5eb548910abac517d",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust-src",
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-04-18/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "7b52449d1dcdb4fb1b0f1586347a7b4fd31ad9c99a53d84e680cdf673d135979",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-09-05/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "28dcd5840675afd4c32a978d2f2ec5c3847410d63a40e944a5aebd6afcc1fa59",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-04-18/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "7c4ed45a18f8b61cb7d5d091df281704f19d7ce29c0add29d1f2f46b34f83ded",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-09-05/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "2b3fd39b08c96807ca9131dac30b4b3dc3ae6bdad1b219810fbade97891eb97e",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-01-02/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "1739d91858e924c9681a7583893c595e2f078f23803996ddfb4b9f924f88a051",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-01-09/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "2d6baf57929d677c895f0703d8401fe251b2b1cf929d02729160de35e4c71d6f",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-01-02/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "caa546120973bfbe1650c7e60b562d60aedd9939972665374a70547ea2e8344d",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-01-09/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "ffe1e03b60feabc1b53d0f16ba29c80835f2a586a23d4c0d828bf03eb40fb0e4",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -174,8 +174,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.10.0/mold-1.10.0-x86_64-linux.tar.gz",
-                    "sha256": "b1d97a63700a290b3ab4cbc8e1c705b36d7f148967648681f053bb8c319190a0",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.10.1/mold-1.10.1-x86_64-linux.tar.gz",
+                    "sha256": "7524fe67f917d5287b2f7a7d6401e2625fa3f5f84bc6b8d9b487d6cb08876488",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 241732,
@@ -189,8 +189,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.10.0/mold-1.10.0-aarch64-linux.tar.gz",
-                    "sha256": "71698d4835a9fa2815d88f4d92e66657a53cc1b9006c7bc80e960eb292885279",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.10.1/mold-1.10.1-aarch64-linux.tar.gz",
+                    "sha256": "5ad793bce5c40c2fc5c8afb77188fd504cedd2a3160baee04091bd294385305b",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 241732,

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -174,8 +174,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.4.2/mold-1.4.2-x86_64-linux.tar.gz",
-                    "sha256": "584768879ef75e57c1a129ae159f9ef65bed565d510e09fc7d9d98bc58b3d534",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.5.0/mold-1.5.0-x86_64-linux.tar.gz",
+                    "sha256": "dfbd60793f7ffb2dde5ea475744ca3c6e0a467a33d5706eb17ce115637727486",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 241732,
@@ -189,8 +189,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.4.2/mold-1.4.2-aarch64-linux.tar.gz",
-                    "sha256": "04ae35bb1d2120c901ba7887b33808081252c9e8997c90ba6ace8152ffaf28d6",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.5.0/mold-1.5.0-aarch64-linux.tar.gz",
+                    "sha256": "03e080ed8cd1e56977391a4e15c84d75d8420558f8b4e7a75354e363b9b98424",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 241732,

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-09-19/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "5347c331c4d2d43f6791c44c0ee7f7e4a5852146304e487f64865a40a866f1e5",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-09-26/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "1a92fa7cfa20611087924fb32b5c722a8076d82ada73943909c259d1a9360a72",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-09-19/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "095d024a0351eaf26bcea931d1145cbd95ef934048235e2812fdedfc717c87a3",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-09-26/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "59027b0e38b3e091419e70538dafffd03265b9d5b76c1255c3f119660af8ffbf",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-12-19/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "3b4fed379bd86ceabbc9b6762ce6610bf0e803fced62eacd031ac871bd47cc6c",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-12-26/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "a02548023aecc66f5c6e6309ef29b2d22f2095af3a15cf9d2491c4fc289dae84",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-12-19/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "28fb14245c5985e0410dcc7202ae592c4b0aec9de883a910aed304d43bcd13ba",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-12-26/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "3b18a90dd715d94e81dd622046db4a2d94e5691f6edf67160aa8ddef4708197f",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -174,8 +174,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.6.0/mold-1.6.0-x86_64-linux.tar.gz",
-                    "sha256": "d43b2215018f1c2280fcd64c891c570754c0322e817d75a80f9cd149b077a930",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.7.0/mold-1.7.0-x86_64-linux.tar.gz",
+                    "sha256": "113f0db9915054f558a4e41cf6dbc45b7fd45076a4064830112fac8f82091fd9",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 241732,
@@ -189,8 +189,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.6.0/mold-1.6.0-aarch64-linux.tar.gz",
-                    "sha256": "5897ac0289dce8bcd62b067900e19f29af118b1aa2f8ce7cbcc0ffb256a6c88a",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.7.0/mold-1.7.0-aarch64-linux.tar.gz",
+                    "sha256": "bb6ec2ec25f2c4b03bb1e66b303673e2203431115e1b907da9a528c64b49e65f",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 241732,

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-12-12/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "625b1282c41dd192c63b269a4455cb9e2305fa831dd7195ab81fd1fcadc28caf",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-12-19/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "3b4fed379bd86ceabbc9b6762ce6610bf0e803fced62eacd031ac871bd47cc6c",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-12-12/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "5d741017dfa47bce76141fd9e96f66c1e2d6969abeccb62855e4af3950df8678",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-12-19/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "28fb14245c5985e0410dcc7202ae592c4b0aec9de883a910aed304d43bcd13ba",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -27,8 +27,8 @@
                         "aarch64"
                     ],
                     "dest": "rust-armv7-unknown-linux-gnueabihf",
-                    "url": "https://static.rust-lang.org/dist/2023-01-10/rust-1.66.1-armv7-unknown-linux-gnueabihf.tar.xz",
-                    "sha256": "4aeff6472c44e5a8756b63c493dbb3820739dc80f5e9e62dd509f32cd5a724c8",
+                    "url": "https://static.rust-lang.org/dist/2023-01-26/rust-1.67.0-armv7-unknown-linux-gnueabihf.tar.xz",
+                    "sha256": "65e1dcac8154181532179d6dd28a3ec19baea875c38556437cf5fae72281531e",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -41,8 +41,8 @@
                         "aarch64"
                     ],
                     "dest": "rust-aarch64-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2023-01-10/rust-1.66.1-aarch64-unknown-linux-gnu.tar.xz",
-                    "sha256": "a1279760f91b3571733e0b0268128d143be2734916753900b5fe7b8ecc3c0900",
+                    "url": "https://static.rust-lang.org/dist/2023-01-26/rust-1.67.0-aarch64-unknown-linux-gnu.tar.xz",
+                    "sha256": "5a108891cab3fd0567bf8c2b44f18c045c067c607bbec3ea62b02ad40809b151",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -55,8 +55,8 @@
                         "x86_64"
                     ],
                     "dest": "rust-x86_64-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2023-01-10/rust-1.66.1-x86_64-unknown-linux-gnu.tar.xz",
-                    "sha256": "a201aa4595ec8015662b7103b1409a4787c6d1f1d540bb68746633527d855858",
+                    "url": "https://static.rust-lang.org/dist/2023-01-26/rust-1.67.0-x86_64-unknown-linux-gnu.tar.xz",
+                    "sha256": "e6345aebeba55f39cb35fc06a3ac6c43c35f596309a6ed26023b1898346419bd",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -71,8 +71,8 @@
                         "x86_64"
                     ],
                     "dest": "rust-i686-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2023-01-10/rust-1.66.1-i686-unknown-linux-gnu.tar.xz",
-                    "sha256": "835b4e1b4d396674f7866a83b9a4f44db16fd12f01a7eaed527282b3700a9b92",
+                    "url": "https://static.rust-lang.org/dist/2023-01-26/rust-1.67.0-i686-unknown-linux-gnu.tar.xz",
+                    "sha256": "2ba12fe020b17de3a6fe7633c59ab50ef44f9715caa858077aad3301408f583c",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -82,8 +82,8 @@
                 {
                     "type": "archive",
                     "dest": "rust-src",
-                    "url": "https://static.rust-lang.org/dist/2023-01-10/rust-src-1.66.1.tar.xz",
-                    "sha256": "752aa6cb02db94dc246cdcef4186f4e1d1640b72a7954b9cda01f479a7d1ed76",
+                    "url": "https://static.rust-lang.org/dist/2023-01-26/rust-src-1.67.0.tar.xz",
+                    "sha256": "4b8cc00fb5ea48aec48ae31ef09376d76e1ffa034f07d938fa56653bdc6d0875",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust-src",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-09-05/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "28dcd5840675afd4c32a978d2f2ec5c3847410d63a40e944a5aebd6afcc1fa59",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-09-12/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "7cffcc22557ede856096a3e4021b4f83176dd6b3ac4e222e330268707d98a3bd",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-09-05/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "2b3fd39b08c96807ca9131dac30b4b3dc3ae6bdad1b219810fbade97891eb97e",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-09-12/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "1b3857080b4d0d5c713540c802fdd166286480dea4efc67d9f135b56fd63995a",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-10-17/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "323cad202e161c4e4b9bc7669552fd9c6e55b2368cccf2c0d61ef86e8caf7dc9",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-10-24/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "7b5f8eaed7770a2e38564872cd92a9c23e24e170c123c39a84b09477130a2892",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-10-17/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "d4c5c1a6df116a27f548ed17ffb57594f97713cde323c932cf7ba9d88dc9c21a",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-10-24/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "1e81ff975eab14cea247e9f77e88ecf44760789f49da46d1e9745fefc70893d8",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -174,8 +174,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.7.1/mold-1.7.1-x86_64-linux.tar.gz",
-                    "sha256": "66b38b8ab3143f23c1eaad598dd9055ce84f39729f92d63eddbd856a73d65784",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.8.0/mold-1.8.0-x86_64-linux.tar.gz",
+                    "sha256": "308b8a3c8a44e232348a13764f581538ec80c28c420167fd6dad3d64c05e17c2",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 241732,
@@ -189,8 +189,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.7.1/mold-1.7.1-aarch64-linux.tar.gz",
-                    "sha256": "9c43875c00972c61196eac41fca297403ec24c36b9232d1a6aa1cb84ce40f829",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.8.0/mold-1.8.0-aarch64-linux.tar.gz",
+                    "sha256": "b9464df5f3dd36e17f473173afcd853f1cc2c357e52ec2b896950283c2a2adfd",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 241732,

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-12-26/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "a02548023aecc66f5c6e6309ef29b2d22f2095af3a15cf9d2491c4fc289dae84",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-01-02/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "1739d91858e924c9681a7583893c595e2f078f23803996ddfb4b9f924f88a051",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-12-26/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "3b18a90dd715d94e81dd622046db4a2d94e5691f6edf67160aa8ddef4708197f",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-01-02/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "caa546120973bfbe1650c7e60b562d60aedd9939972665374a70547ea2e8344d",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-11-07/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "319b445878208c6eb02a0c6167c7591bc2ed64fe018d9d962e24567ba1f11fab",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-11-14/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "540dbcd6e9840105c70ed1d629c2e5822dc494c7387c7db51f1e5704b75c5d23",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-11-07/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "a584dd5682d3ffb10c59b1421cddd8a74e7bc2372aea492c4a383e2bad4389fa",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-11-14/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "0f40bcd2527314e1332c45a96cff3c7f06f8e2b5f6e5e388bc307bbc64555c0e",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -174,8 +174,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.5.0/mold-1.5.0-x86_64-linux.tar.gz",
-                    "sha256": "dfbd60793f7ffb2dde5ea475744ca3c6e0a467a33d5706eb17ce115637727486",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.5.1/mold-1.5.1-x86_64-linux.tar.gz",
+                    "sha256": "2b4006aa3935bd65e448e0d0f0e70fe57c4d9a12074435e69bc31b212fdaa160",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 241732,
@@ -189,8 +189,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.5.0/mold-1.5.0-aarch64-linux.tar.gz",
-                    "sha256": "03e080ed8cd1e56977391a4e15c84d75d8420558f8b4e7a75354e363b9b98424",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.5.1/mold-1.5.1-aarch64-linux.tar.gz",
+                    "sha256": "d71e728a6e2d0b6f58536ddd97f8592552d060b0cb9920a23b7db79c11efb26b",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 241732,


### PR DESCRIPTION
This should provide a more recent Rust for 21.08

Use case: Tauri app that still depend on a GtkWebKit that is too old for GNOME 43.