### PR TITLE
23.08beta

### DIFF
--- a/org.freedesktop.Sdk.Extension.rust-stable.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.rust-stable.appdata.xml
@@ -12,6 +12,7 @@
   <translation/>
   <update_contact>danigm@gnome.org</update_contact>
   <releases>
+    <release version="1.64.0" date="2022-09-22"/>
     <release version="1.63.0" date="2022-08-11"/>
     <release version="1.60.0" date="2022-04-07"/>
     <release version="1.59.0" date="2022-02-24"/>

--- a/org.freedesktop.Sdk.Extension.rust-stable.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.rust-stable.appdata.xml
@@ -12,6 +12,7 @@
   <translation/>
   <update_contact>danigm@gnome.org</update_contact>
   <releases>
+    <release version="1.66.0" date="2022-12-15"/>
     <release version="1.65.0" date="2022-11-03"/>
     <release version="1.64.0" date="2022-09-22"/>
     <release version="1.63.0" date="2022-08-11"/>

--- a/org.freedesktop.Sdk.Extension.rust-stable.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.rust-stable.appdata.xml
@@ -12,6 +12,7 @@
   <translation/>
   <update_contact>danigm@gnome.org</update_contact>
   <releases>
+    <release version="1.66.1" date="2023-01-10"/>
     <release version="1.66.0" date="2022-12-15"/>
     <release version="1.65.0" date="2022-11-03"/>
     <release version="1.64.0" date="2022-09-22"/>

--- a/org.freedesktop.Sdk.Extension.rust-stable.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.rust-stable.appdata.xml
@@ -12,6 +12,7 @@
   <translation/>
   <update_contact>danigm@gnome.org</update_contact>
   <releases>
+    <release version="1.67.0" date="2023-01-26"/>
     <release version="1.66.1" date="2023-01-10"/>
     <release version="1.66.0" date="2022-12-15"/>
     <release version="1.65.0" date="2022-11-03"/>

--- a/org.freedesktop.Sdk.Extension.rust-stable.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.rust-stable.appdata.xml
@@ -12,6 +12,7 @@
   <translation/>
   <update_contact>danigm@gnome.org</update_contact>
   <releases>
+    <release version="1.63.0" date="2022-08-11"/>
     <release version="1.60.0" date="2022-04-07"/>
     <release version="1.59.0" date="2022-02-24"/>
     <release version="1.58.1" date="2022-01-20"/>

--- a/org.freedesktop.Sdk.Extension.rust-stable.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.rust-stable.appdata.xml
@@ -12,6 +12,7 @@
   <translation/>
   <update_contact>danigm@gnome.org</update_contact>
   <releases>
+    <release version="1.65.0" date="2022-11-03"/>
     <release version="1.64.0" date="2022-09-22"/>
     <release version="1.63.0" date="2022-08-11"/>
     <release version="1.60.0" date="2022-04-07"/>

--- a/org.freedesktop.Sdk.Extension.rust-stable.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.rust-stable.appdata.xml
@@ -12,6 +12,7 @@
   <translation/>
   <update_contact>danigm@gnome.org</update_contact>
   <releases>
+    <release version="1.67.1" date="2023-02-09"/>
     <release version="1.67.0" date="2023-01-26"/>
     <release version="1.66.1" date="2023-01-10"/>
     <release version="1.66.0" date="2022-12-15"/>

--- a/org.freedesktop.Sdk.Extension.rust-stable.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.rust-stable.appdata.xml
@@ -12,6 +12,7 @@
   <translation/>
   <update_contact>danigm@gnome.org</update_contact>
   <releases>
+    <release version="1.68.2" date="2023-03-28"/>
     <release version="1.68.1" date="2023-03-23"/>
     <release version="1.68.0" date="2023-03-09"/>
     <release version="1.67.1" date="2023-02-09"/>

--- a/org.freedesktop.Sdk.Extension.rust-stable.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.rust-stable.appdata.xml
@@ -12,6 +12,7 @@
   <translation/>
   <update_contact>danigm@gnome.org</update_contact>
   <releases>
+    <release version="1.68.0" date="2023-03-09"/>
     <release version="1.67.1" date="2023-02-09"/>
     <release version="1.67.0" date="2023-01-26"/>
     <release version="1.66.1" date="2023-01-10"/>

--- a/org.freedesktop.Sdk.Extension.rust-stable.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.rust-stable.appdata.xml
@@ -12,6 +12,7 @@
   <translation/>
   <update_contact>danigm@gnome.org</update_contact>
   <releases>
+    <release version="1.69.0" date="2023-04-20"/>
     <release version="1.68.2" date="2023-03-28"/>
     <release version="1.68.1" date="2023-03-23"/>
     <release version="1.68.0" date="2023-03-09"/>

--- a/org.freedesktop.Sdk.Extension.rust-stable.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.rust-stable.appdata.xml
@@ -12,6 +12,7 @@
   <translation/>
   <update_contact>danigm@gnome.org</update_contact>
   <releases>
+    <release version="1.68.1" date="2023-03-23"/>
     <release version="1.68.0" date="2023-03-09"/>
     <release version="1.67.1" date="2023-02-09"/>
     <release version="1.67.0" date="2023-01-26"/>

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-03-27/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "d0d4e48a1fadd76fc7f0594d551cdc9659e6445e51c5ef6ecd8cd84331554979",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-04-03/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "e4ae98b5ef7e00ecefc0d6aef8637b2768999dfe20c4347e40d63dc78b4cc926",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-03-27/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "61bc21dc0b4629ce65a673fd880feb720683a9aedd4b53d832b5bd5a9d6b34e1",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-04-03/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "e3da17fe608db5b8182961c06fb899f02ac78c080b60726aeca2fe9b56362438",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-11-28/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "fe2433498eab3c4b49ce1c82f6eb66c9bb5218a3851b85ad61fc5724f82e7f4e",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-12-05/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "66d03c887981fd9d375c263f3831ceb34d4cd6b54bdcaf15c770a0f86237670b",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-11-28/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "748da2c68e16ad20dcba3b7c94a7ac348fabcaf92ca457a2f7125ca2a82c495c",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-12-05/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "6901271ac5cdcb82393cf0c0e142ddcce6e200196f0d33f340991cce8c335591",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -135,7 +135,7 @@
                         "x86_64"
                     ],
                     "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-01-09/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "2d6baf57929d677c895f0703d8401fe251b2b1cf929d02729160de35e4c71d6f",
+                    "sha256": "32e84be6bab29c9dc194754e9a58a0d1ff118b9ddd835fa64e02d8960a83bcd8",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-01-23/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "8b4d9de99f12273d4555e773c2fb76b0a5b5f1b3e44e6ecc415ec99417b94a0d",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-01-30/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "ca1fbd67a5efd558abebe8559264f8b1bd4f420647b844bc3bd247fa0f5d549e",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-01-23/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "95d584bd19145541079487f7a0b7be46294bd1668e6039a70241e2961a7804c5",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-01-30/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "1fcb29c29be15cb17a38a83693a957bb8e704421e5a0b97599521402019b86bc",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-02-27/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "2b2552e26ac1b0ae2180d6561de07db2eda9584cda05933a774fb8998a73c074",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-03-06/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "7d7f36149507eb084edf15f303a55885d881dff3e333857dca94c03052bbc222",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-02-27/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "28236f7da0098d334f71363ca5c40d471c19668c1f0a5414f5fb418ee829295e",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-03-06/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "c6e89504c91b354b97ef2426729b8cda69082b901d9b22bd2679908a264abcce",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-10-10/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "38535e9231285123e1dfa838908e61624f0f5dd8cb58e255408b30ea19a3a6eb",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-10-17/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "323cad202e161c4e4b9bc7669552fd9c6e55b2368cccf2c0d61ef86e8caf7dc9",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-10-10/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "1afb87401b3dfa63bad9f2041e87849975ec1af2fbdf780792a8b587295e2c33",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-10-17/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "d4c5c1a6df116a27f548ed17ffb57594f97713cde323c932cf7ba9d88dc9c21a",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -180,7 +180,7 @@
                         "type": "anitya",
                         "project-id": 241732,
                         "stable-only": true,
-                        "url-template": "https://github.com/rui314/mold/releases/download/v1.2/mold-$version-x86_64-linux.tar.gz"
+                        "url-template": "https://github.com/rui314/mold/releases/download/v$version/mold-$version-x86_64-linux.tar.gz"
                     }
                 },
                 {
@@ -195,7 +195,7 @@
                         "type": "anitya",
                         "project-id": 241732,
                         "stable-only": true,
-                        "url-template": "https://github.com/rui314/mold/releases/download/v1.2/mold-$version-aarch64-linux.tar.gz"
+                        "url-template": "https://github.com/rui314/mold/releases/download/v$version/mold-$version-aarch64-linux.tar.gz"
                     }
                 }
             ],

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-11-14/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "540dbcd6e9840105c70ed1d629c2e5822dc494c7387c7db51f1e5704b75c5d23",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-11-21/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "4ebdf56a65686acc79f0261d20bf7392afb477a53454f247397ec1ae8d70d9ba",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-11-14/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "0f40bcd2527314e1332c45a96cff3c7f06f8e2b5f6e5e388bc307bbc64555c0e",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-11-21/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "d13aceae777d1565987fcc28d0dff3f790dd2774a6ac0964b522624a1778a3d9",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -1,10 +1,10 @@
 {
     "id": "org.freedesktop.Sdk.Extension.rust-stable",
-    "branch": "22.08beta",
+    "branch": "22.08",
     "runtime": "org.freedesktop.Sdk",
     "build-extension": true,
     "sdk": "org.freedesktop.Sdk",
-    "runtime-version": "22.08beta",
+    "runtime-version": "22.08",
     "sdk-extensions": [],
     "separate-locales": false,
     "appstream-compose": false,

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-09-26/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "1a92fa7cfa20611087924fb32b5c722a8076d82ada73943909c259d1a9360a72",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-10-03/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "b48013f713199533d4dff970ed24273563a5543579057a0a571bfe87b44ca2fd",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-09-26/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "59027b0e38b3e091419e70538dafffd03265b9d5b76c1255c3f119660af8ffbf",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-10-03/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "1aad3db25f6e0c43c15d284fb68b3a893ab01585412af914db3eb96fe102e4be",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -27,8 +27,8 @@
                         "aarch64"
                     ],
                     "dest": "rust-armv7-unknown-linux-gnueabihf",
-                    "url": "https://static.rust-lang.org/dist/2023-01-26/rust-1.67.0-armv7-unknown-linux-gnueabihf.tar.xz",
-                    "sha256": "65e1dcac8154181532179d6dd28a3ec19baea875c38556437cf5fae72281531e",
+                    "url": "https://static.rust-lang.org/dist/2023-02-09/rust-1.67.1-armv7-unknown-linux-gnueabihf.tar.xz",
+                    "sha256": "d05c97b72b236a8dcddcb6f4ddfb7c8a49ad627a3038a8f7b4952085e246b29f",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -41,8 +41,8 @@
                         "aarch64"
                     ],
                     "dest": "rust-aarch64-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2023-01-26/rust-1.67.0-aarch64-unknown-linux-gnu.tar.xz",
-                    "sha256": "5a108891cab3fd0567bf8c2b44f18c045c067c607bbec3ea62b02ad40809b151",
+                    "url": "https://static.rust-lang.org/dist/2023-02-09/rust-1.67.1-aarch64-unknown-linux-gnu.tar.xz",
+                    "sha256": "b7b8e8b70cae457092661894efa5a4861ef4f0e20f2f617d05d6f17b1f780a68",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -55,8 +55,8 @@
                         "x86_64"
                     ],
                     "dest": "rust-x86_64-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2023-01-26/rust-1.67.0-x86_64-unknown-linux-gnu.tar.xz",
-                    "sha256": "e6345aebeba55f39cb35fc06a3ac6c43c35f596309a6ed26023b1898346419bd",
+                    "url": "https://static.rust-lang.org/dist/2023-02-09/rust-1.67.1-x86_64-unknown-linux-gnu.tar.xz",
+                    "sha256": "7dbb718bdb09adad7e36b9a413e571863913682495527f7f2d6507ea2c068542",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -71,8 +71,8 @@
                         "x86_64"
                     ],
                     "dest": "rust-i686-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2023-01-26/rust-1.67.0-i686-unknown-linux-gnu.tar.xz",
-                    "sha256": "2ba12fe020b17de3a6fe7633c59ab50ef44f9715caa858077aad3301408f583c",
+                    "url": "https://static.rust-lang.org/dist/2023-02-09/rust-1.67.1-i686-unknown-linux-gnu.tar.xz",
+                    "sha256": "b686a2d0d1648e1b84def715dd65a85a3d2802b33ecf65808bdb2ed639aec7d3",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -82,8 +82,8 @@
                 {
                     "type": "archive",
                     "dest": "rust-src",
-                    "url": "https://static.rust-lang.org/dist/2023-01-26/rust-src-1.67.0.tar.xz",
-                    "sha256": "4b8cc00fb5ea48aec48ae31ef09376d76e1ffa034f07d938fa56653bdc6d0875",
+                    "url": "https://static.rust-lang.org/dist/2023-02-09/rust-src-1.67.1.tar.xz",
+                    "sha256": "186502914ae332198ee8c2180676c6c49faef3559cbddcbe4db5244730e3ae3a",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust-src",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-10-31/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "b4c8d190a83bd386de73a38b987ca13a92651fc1ad47ccbd20c8ad4fcb2b02c1",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-11-07/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "319b445878208c6eb02a0c6167c7591bc2ed64fe018d9d962e24567ba1f11fab",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-10-31/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "177ae838352164fd007eddfe2f89e1ee651ac9e9bc7df5a491179aa30dba2918",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-11-07/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "a584dd5682d3ffb10c59b1421cddd8a74e7bc2372aea492c4a383e2bad4389fa",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -174,8 +174,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.8.0/mold-1.8.0-x86_64-linux.tar.gz",
-                    "sha256": "308b8a3c8a44e232348a13764f581538ec80c28c420167fd6dad3d64c05e17c2",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.9.0/mold-1.9.0-x86_64-linux.tar.gz",
+                    "sha256": "e534e7a6e2fa88e749bd4579d1bfe6397fad2393bae8450c18aba339ac567a9f",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 241732,
@@ -189,8 +189,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.8.0/mold-1.8.0-aarch64-linux.tar.gz",
-                    "sha256": "b9464df5f3dd36e17f473173afcd853f1cc2c357e52ec2b896950283c2a2adfd",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.9.0/mold-1.9.0-aarch64-linux.tar.gz",
+                    "sha256": "826d6599ffc8a03fa5858325d2a9b8866c6a38e3bb45a0c4d84784d5482b756c",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 241732,

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-10-03/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "b48013f713199533d4dff970ed24273563a5543579057a0a571bfe87b44ca2fd",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-10-10/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "38535e9231285123e1dfa838908e61624f0f5dd8cb58e255408b30ea19a3a6eb",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-10-03/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "1aad3db25f6e0c43c15d284fb68b3a893ab01585412af914db3eb96fe102e4be",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-10-10/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "1afb87401b3dfa63bad9f2041e87849975ec1af2fbdf780792a8b587295e2c33",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -27,8 +27,8 @@
                         "aarch64"
                     ],
                     "dest": "rust-armv7-unknown-linux-gnueabihf",
-                    "url": "https://static.rust-lang.org/dist/2022-11-03/rust-1.65.0-armv7-unknown-linux-gnueabihf.tar.xz",
-                    "sha256": "c34e277f6883e0038633175b55d0af858a1f8d329c65d83fa00d125edb063352",
+                    "url": "https://static.rust-lang.org/dist/2022-12-15/rust-1.66.0-armv7-unknown-linux-gnueabihf.tar.xz",
+                    "sha256": "6e3f65eb819956624569b5fed56f49e808e1fd5845bcb696c4fd36d0ab923617",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -41,8 +41,8 @@
                         "aarch64"
                     ],
                     "dest": "rust-aarch64-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2022-11-03/rust-1.65.0-aarch64-unknown-linux-gnu.tar.xz",
-                    "sha256": "b3a83a9585b8c4ede4eab2a11b3f96895f676d8b46c9642140c4fefd5c309ed1",
+                    "url": "https://static.rust-lang.org/dist/2022-12-15/rust-1.66.0-aarch64-unknown-linux-gnu.tar.xz",
+                    "sha256": "e8d853383355aa17fd8d7efae740ac0f18b3a5f452c9ac62f5042fc96ebda3e9",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -55,8 +55,8 @@
                         "x86_64"
                     ],
                     "dest": "rust-x86_64-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2022-11-03/rust-1.65.0-x86_64-unknown-linux-gnu.tar.xz",
-                    "sha256": "9455cab767f7b9f46259aac8d953f15f11b3d65513384e2b0a5e77d0432ae82f",
+                    "url": "https://static.rust-lang.org/dist/2022-12-15/rust-1.66.0-x86_64-unknown-linux-gnu.tar.xz",
+                    "sha256": "a656328e1cd36b253bf39807b5a3eacdf0ce7d982fc9fb51a026f273386de84a",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -71,8 +71,8 @@
                         "x86_64"
                     ],
                     "dest": "rust-i686-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2022-11-03/rust-1.65.0-i686-unknown-linux-gnu.tar.xz",
-                    "sha256": "50595b96f98e0940bbfe00209d6c233e9158e140ecd6088ad3bd53f89b123e9d",
+                    "url": "https://static.rust-lang.org/dist/2022-12-15/rust-1.66.0-i686-unknown-linux-gnu.tar.xz",
+                    "sha256": "c9551f9650fcaf74ea4fb6874b6853f9ffecb6925e7a087afb4f36840e5b7b8d",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -82,8 +82,8 @@
                 {
                     "type": "archive",
                     "dest": "rust-src",
-                    "url": "https://static.rust-lang.org/dist/2022-11-03/rust-src-1.65.0.tar.xz",
-                    "sha256": "7dfdbecad68d9fbc64574eb403aa4815adef563dd6fb1d8a1be3b9fff364deb2",
+                    "url": "https://static.rust-lang.org/dist/2022-12-15/rust-src-1.66.0.tar.xz",
+                    "sha256": "782d392e8401518a75914a39b958be0a210b254d5d39127839739f5d4d51a2eb",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust-src",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-01-16/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "1a08c6cbf51cb0897c4d2033e81ddd9ecc69201a2c27830ea310ce67c021b4da",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-01-23/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "8b4d9de99f12273d4555e773c2fb76b0a5b5f1b3e44e6ecc415ec99417b94a0d",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-01-16/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "d03a9ffb4c88e5bbf634ef656b2464754103fe7b0983a191671046973d463dfc",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-01-23/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "95d584bd19145541079487f7a0b7be46294bd1668e6039a70241e2961a7804c5",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -174,8 +174,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.10.1/mold-1.10.1-x86_64-linux.tar.gz",
-                    "sha256": "7524fe67f917d5287b2f7a7d6401e2625fa3f5f84bc6b8d9b487d6cb08876488",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.11.0/mold-1.11.0-x86_64-linux.tar.gz",
+                    "sha256": "bf788940db4a9ac19e7745c821bf6ee18ff4d75441a803d84f86c9f3b0aa2a5e",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 241732,
@@ -189,8 +189,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.10.1/mold-1.10.1-aarch64-linux.tar.gz",
-                    "sha256": "5ad793bce5c40c2fc5c8afb77188fd504cedd2a3160baee04091bd294385305b",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.11.0/mold-1.11.0-aarch64-linux.tar.gz",
+                    "sha256": "4d7f0cc976ed1dfde1ceeaadd16829427a477eba1b49ff82dd490395f32eb78c",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 241732,

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-02-20/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "3be790fcc6f844a4c9e18dbefba53ece04c262d84283387c5f45d9aaf123a0b0",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-02-27/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "2b2552e26ac1b0ae2180d6561de07db2eda9584cda05933a774fb8998a73c074",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-02-20/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "87234692e4d16b8f8395dbb56c1d7799005a5e0abd8d223b69dcde57b6eae5f7",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-02-27/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "28236f7da0098d334f71363ca5c40d471c19668c1f0a5414f5fb418ee829295e",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -174,8 +174,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.9.0/mold-1.9.0-x86_64-linux.tar.gz",
-                    "sha256": "e534e7a6e2fa88e749bd4579d1bfe6397fad2393bae8450c18aba339ac567a9f",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.10.0/mold-1.10.0-x86_64-linux.tar.gz",
+                    "sha256": "b1d97a63700a290b3ab4cbc8e1c705b36d7f148967648681f053bb8c319190a0",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 241732,
@@ -189,8 +189,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.9.0/mold-1.9.0-aarch64-linux.tar.gz",
-                    "sha256": "826d6599ffc8a03fa5858325d2a9b8866c6a38e3bb45a0c4d84784d5482b756c",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.10.0/mold-1.10.0-aarch64-linux.tar.gz",
+                    "sha256": "71698d4835a9fa2815d88f4d92e66657a53cc1b9006c7bc80e960eb292885279",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 241732,

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-10-24/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "7b5f8eaed7770a2e38564872cd92a9c23e24e170c123c39a84b09477130a2892",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-10-31/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "b4c8d190a83bd386de73a38b987ca13a92651fc1ad47ccbd20c8ad4fcb2b02c1",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-10-24/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "1e81ff975eab14cea247e9f77e88ecf44760789f49da46d1e9745fefc70893d8",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-10-31/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "177ae838352164fd007eddfe2f89e1ee651ac9e9bc7df5a491179aa30dba2918",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-02-13/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "e292e10ff03b3bea4594e8828ef492e403787ea63ad2dc55c214437b64dd489d",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-02-20/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "3be790fcc6f844a4c9e18dbefba53ece04c262d84283387c5f45d9aaf123a0b0",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-02-13/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "691932abeb7102f1708b35e8c8df5d488a347de264ef02000c28d386f462d363",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-02-20/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "87234692e4d16b8f8395dbb56c1d7799005a5e0abd8d223b69dcde57b6eae5f7",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -174,8 +174,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.7.0/mold-1.7.0-x86_64-linux.tar.gz",
-                    "sha256": "113f0db9915054f558a4e41cf6dbc45b7fd45076a4064830112fac8f82091fd9",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.7.1/mold-1.7.1-x86_64-linux.tar.gz",
+                    "sha256": "66b38b8ab3143f23c1eaad598dd9055ce84f39729f92d63eddbd856a73d65784",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 241732,
@@ -189,8 +189,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.7.0/mold-1.7.0-aarch64-linux.tar.gz",
-                    "sha256": "bb6ec2ec25f2c4b03bb1e66b303673e2203431115e1b907da9a528c64b49e65f",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.7.1/mold-1.7.1-aarch64-linux.tar.gz",
+                    "sha256": "9c43875c00972c61196eac41fca297403ec24c36b9232d1a6aa1cb84ce40f829",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 241732,

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-02-06/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "2a612017c6fd8d7f79d86e3f2f021e58b5ba3a544b913ea02541f5bf9524a0cc",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-02-13/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "e292e10ff03b3bea4594e8828ef492e403787ea63ad2dc55c214437b64dd489d",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-02-06/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "9d9f93603887bbd7a7a23d8d8add4699ae025286ffae301e881a44b393f1156f",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-02-13/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "691932abeb7102f1708b35e8c8df5d488a347de264ef02000c28d386f462d363",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-01-09/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "32e84be6bab29c9dc194754e9a58a0d1ff118b9ddd835fa64e02d8960a83bcd8",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-01-16/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "1a08c6cbf51cb0897c4d2033e81ddd9ecc69201a2c27830ea310ce67c021b4da",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-01-09/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "ffe1e03b60feabc1b53d0f16ba29c80835f2a586a23d4c0d828bf03eb40fb0e4",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-01-16/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "d03a9ffb4c88e5bbf634ef656b2464754103fe7b0983a191671046973d463dfc",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -27,8 +27,8 @@
                         "aarch64"
                     ],
                     "dest": "rust-armv7-unknown-linux-gnueabihf",
-                    "url": "https://static.rust-lang.org/dist/2023-03-09/rust-1.68.0-armv7-unknown-linux-gnueabihf.tar.xz",
-                    "sha256": "61b4131b65ebe428802236071374d1efa374c7fa038e1795f17fd70fb057fba8",
+                    "url": "https://static.rust-lang.org/dist/2023-03-23/rust-1.68.1-armv7-unknown-linux-gnueabihf.tar.xz",
+                    "sha256": "6ba1691daea0d7497ccf7ce9c988762121f2639a8dd48de3c3b4a0173069da62",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -41,8 +41,8 @@
                         "aarch64"
                     ],
                     "dest": "rust-aarch64-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2023-03-09/rust-1.68.0-aarch64-unknown-linux-gnu.tar.xz",
-                    "sha256": "79cb5c840e44d0e3623335e59c2849dd73e0048fc6f97f2d351e88b0bd85040a",
+                    "url": "https://static.rust-lang.org/dist/2023-03-23/rust-1.68.1-aarch64-unknown-linux-gnu.tar.xz",
+                    "sha256": "1ec89e697f5e491749eb534540f8adb7f315e63916ccc1c59a38a9349b59b1bd",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -55,8 +55,8 @@
                         "x86_64"
                     ],
                     "dest": "rust-x86_64-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2023-03-09/rust-1.68.0-x86_64-unknown-linux-gnu.tar.xz",
-                    "sha256": "183d53f7488095550788fe38eff80542d68e6bd92ee48442d2ce0bd60a7eceaf",
+                    "url": "https://static.rust-lang.org/dist/2023-03-23/rust-1.68.1-x86_64-unknown-linux-gnu.tar.xz",
+                    "sha256": "a6f954e908675e20819cce5e0fc9e13da0b932e2a5c554b2fb14745188d8ef42",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -71,8 +71,8 @@
                         "x86_64"
                     ],
                     "dest": "rust-i686-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2023-03-09/rust-1.68.0-i686-unknown-linux-gnu.tar.xz",
-                    "sha256": "650b7cd7a13e4739de39e7e89c534600cfb33afdc6d7774b87ed64e5b7cd17a3",
+                    "url": "https://static.rust-lang.org/dist/2023-03-23/rust-1.68.1-i686-unknown-linux-gnu.tar.xz",
+                    "sha256": "ba9da610b317e9b5cd6bf8ba06738d5c58c33555531548f17dc8ec2911e24f21",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -82,8 +82,8 @@
                 {
                     "type": "archive",
                     "dest": "rust-src",
-                    "url": "https://static.rust-lang.org/dist/2023-03-09/rust-src-1.68.0.tar.xz",
-                    "sha256": "55f3791caa40b3fd59dcce3f3188afc3f11d493ae34dfff3f839e76365c14914",
+                    "url": "https://static.rust-lang.org/dist/2023-03-23/rust-src-1.68.1.tar.xz",
+                    "sha256": "891921684825736d57e105c1c80af2dce3580913109a4c9caefb3a1d9e751fa8",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust-src",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -174,8 +174,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.5.1/mold-1.5.1-x86_64-linux.tar.gz",
-                    "sha256": "2b4006aa3935bd65e448e0d0f0e70fe57c4d9a12074435e69bc31b212fdaa160",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.6.0/mold-1.6.0-x86_64-linux.tar.gz",
+                    "sha256": "d43b2215018f1c2280fcd64c891c570754c0322e817d75a80f9cd149b077a930",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 241732,
@@ -189,8 +189,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.5.1/mold-1.5.1-aarch64-linux.tar.gz",
-                    "sha256": "d71e728a6e2d0b6f58536ddd97f8592552d060b0cb9920a23b7db79c11efb26b",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.6.0/mold-1.6.0-aarch64-linux.tar.gz",
+                    "sha256": "5897ac0289dce8bcd62b067900e19f29af118b1aa2f8ce7cbcc0ffb256a6c88a",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 241732,

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-12-05/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "66d03c887981fd9d375c263f3831ceb34d4cd6b54bdcaf15c770a0f86237670b",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-12-12/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "625b1282c41dd192c63b269a4455cb9e2305fa831dd7195ab81fd1fcadc28caf",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-12-05/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "6901271ac5cdcb82393cf0c0e142ddcce6e200196f0d33f340991cce8c335591",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-12-12/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "5d741017dfa47bce76141fd9e96f66c1e2d6969abeccb62855e4af3950df8678",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-03-13/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "e0e11de9f3b2b76590b9f08f4fadb06583ab308d50be595bc11cff908c939276",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-03-20/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "0bcbf744a72ac95241085280ad3b3a3cfd0939c2de8fc0d26753f666249626a4",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-03-13/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "d3803e4fe86f633b3eed5610e9cc6283ab058dd7ca24eb5e0e952338dd9e1f77",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-03-20/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "cc96b03b669eb8b10d59d5d0d81afdec81c2b817fe7f1b1a6175fd08ad4a20b8",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-09-12/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "7cffcc22557ede856096a3e4021b4f83176dd6b3ac4e222e330268707d98a3bd",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-09-19/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "5347c331c4d2d43f6791c44c0ee7f7e4a5852146304e487f64865a40a866f1e5",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-09-12/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "1b3857080b4d0d5c713540c802fdd166286480dea4efc67d9f135b56fd63995a",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-09-19/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "095d024a0351eaf26bcea931d1145cbd95ef934048235e2812fdedfc717c87a3",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -27,8 +27,8 @@
                         "aarch64"
                     ],
                     "dest": "rust-armv7-unknown-linux-gnueabihf",
-                    "url": "https://static.rust-lang.org/dist/2022-12-15/rust-1.66.0-armv7-unknown-linux-gnueabihf.tar.xz",
-                    "sha256": "6e3f65eb819956624569b5fed56f49e808e1fd5845bcb696c4fd36d0ab923617",
+                    "url": "https://static.rust-lang.org/dist/2023-01-10/rust-1.66.1-armv7-unknown-linux-gnueabihf.tar.xz",
+                    "sha256": "4aeff6472c44e5a8756b63c493dbb3820739dc80f5e9e62dd509f32cd5a724c8",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -41,8 +41,8 @@
                         "aarch64"
                     ],
                     "dest": "rust-aarch64-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2022-12-15/rust-1.66.0-aarch64-unknown-linux-gnu.tar.xz",
-                    "sha256": "e8d853383355aa17fd8d7efae740ac0f18b3a5f452c9ac62f5042fc96ebda3e9",
+                    "url": "https://static.rust-lang.org/dist/2023-01-10/rust-1.66.1-aarch64-unknown-linux-gnu.tar.xz",
+                    "sha256": "a1279760f91b3571733e0b0268128d143be2734916753900b5fe7b8ecc3c0900",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -55,8 +55,8 @@
                         "x86_64"
                     ],
                     "dest": "rust-x86_64-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2022-12-15/rust-1.66.0-x86_64-unknown-linux-gnu.tar.xz",
-                    "sha256": "a656328e1cd36b253bf39807b5a3eacdf0ce7d982fc9fb51a026f273386de84a",
+                    "url": "https://static.rust-lang.org/dist/2023-01-10/rust-1.66.1-x86_64-unknown-linux-gnu.tar.xz",
+                    "sha256": "a201aa4595ec8015662b7103b1409a4787c6d1f1d540bb68746633527d855858",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -71,8 +71,8 @@
                         "x86_64"
                     ],
                     "dest": "rust-i686-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2022-12-15/rust-1.66.0-i686-unknown-linux-gnu.tar.xz",
-                    "sha256": "c9551f9650fcaf74ea4fb6874b6853f9ffecb6925e7a087afb4f36840e5b7b8d",
+                    "url": "https://static.rust-lang.org/dist/2023-01-10/rust-1.66.1-i686-unknown-linux-gnu.tar.xz",
+                    "sha256": "835b4e1b4d396674f7866a83b9a4f44db16fd12f01a7eaed527282b3700a9b92",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -82,8 +82,8 @@
                 {
                     "type": "archive",
                     "dest": "rust-src",
-                    "url": "https://static.rust-lang.org/dist/2022-12-15/rust-src-1.66.0.tar.xz",
-                    "sha256": "782d392e8401518a75914a39b958be0a210b254d5d39127839739f5d4d51a2eb",
+                    "url": "https://static.rust-lang.org/dist/2023-01-10/rust-src-1.66.1.tar.xz",
+                    "sha256": "752aa6cb02db94dc246cdcef4186f4e1d1640b72a7954b9cda01f479a7d1ed76",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust-src",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-11-21/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "4ebdf56a65686acc79f0261d20bf7392afb477a53454f247397ec1ae8d70d9ba",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-11-28/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "fe2433498eab3c4b49ce1c82f6eb66c9bb5218a3851b85ad61fc5724f82e7f4e",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-11-21/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "d13aceae777d1565987fcc28d0dff3f790dd2774a6ac0964b522624a1778a3d9",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-11-28/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "748da2c68e16ad20dcba3b7c94a7ac348fabcaf92ca457a2f7125ca2a82c495c",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -174,8 +174,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.2.0/mold-1.2.0-x86_64-linux.tar.gz",
-                    "sha256": "e818703859ce867bb4f57f4f9eed9da427d012bf4bc7a350e27f0d0039dab11f",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.4.2/mold-1.4.2-x86_64-linux.tar.gz",
+                    "sha256": "584768879ef75e57c1a129ae159f9ef65bed565d510e09fc7d9d98bc58b3d534",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 241732,
@@ -189,8 +189,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.2.0/mold-1.2.0-aarch64-linux.tar.gz",
-                    "sha256": "da97071358261cb9c3f6f058879119a544f91a5f692c0042546f30824d2f5ab2",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.4.2/mold-1.4.2-aarch64-linux.tar.gz",
+                    "sha256": "04ae35bb1d2120c901ba7887b33808081252c9e8997c90ba6ace8152ffaf28d6",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 241732,

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-04-03/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "e4ae98b5ef7e00ecefc0d6aef8637b2768999dfe20c4347e40d63dc78b4cc926",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-04-04/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "f0871bc6b1ac5af42dd00d8beffa34aaa7d611f357f1a91b9b0be454bbcf5af3",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-04-03/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "e3da17fe608db5b8182961c06fb899f02ac78c080b60726aeca2fe9b56362438",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-04-04/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "616ed047f099b6b190427c57bf0f1a0a3ec2571d2b0eb8b1f52db687e3e39080",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -27,8 +27,8 @@
                         "aarch64"
                     ],
                     "dest": "rust-armv7-unknown-linux-gnueabihf",
-                    "url": "https://static.rust-lang.org/dist/2022-08-11/rust-1.63.0-armv7-unknown-linux-gnueabihf.tar.xz",
-                    "sha256": "81e9e3dc569047f2a26512609978a4e5d4c06a05a071d44a6d9aadb4d7cbc079",
+                    "url": "https://static.rust-lang.org/dist/2022-09-22/rust-1.64.0-armv7-unknown-linux-gnueabihf.tar.xz",
+                    "sha256": "cad59223ac104dfb3f1ede0efb59f7212f2186da06b5d408cdfaf4710e2b9637",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -41,8 +41,8 @@
                         "aarch64"
                     ],
                     "dest": "rust-aarch64-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2022-08-11/rust-1.63.0-aarch64-unknown-linux-gnu.tar.xz",
-                    "sha256": "963dd3c8b0b1ba970e8608b5bf457c24d5dc471d68f40e5cb62582fbd0461988",
+                    "url": "https://static.rust-lang.org/dist/2022-09-22/rust-1.64.0-aarch64-unknown-linux-gnu.tar.xz",
+                    "sha256": "9081928cced6fc650eaccb88f2ea154dc95c066957b234fa9c0cbe1770479f54",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -55,8 +55,8 @@
                         "x86_64"
                     ],
                     "dest": "rust-x86_64-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2022-08-11/rust-1.63.0-x86_64-unknown-linux-gnu.tar.xz",
-                    "sha256": "be9b25bcf1e564876762e653688e0b5df11fab53048ac18bf77761cf0a0cc465",
+                    "url": "https://static.rust-lang.org/dist/2022-09-22/rust-1.64.0-x86_64-unknown-linux-gnu.tar.xz",
+                    "sha256": "bd69e42f6cfe3ba96d781ad0b4095ddac4f0fc31c1af445018edf6f0aba543e4",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -71,8 +71,8 @@
                         "x86_64"
                     ],
                     "dest": "rust-i686-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2022-08-11/rust-1.63.0-i686-unknown-linux-gnu.tar.xz",
-                    "sha256": "17081489b7efeb3936ed9bee2d21deaa86d76c3fed9be9e582c4325ca6aafae8",
+                    "url": "https://static.rust-lang.org/dist/2022-09-22/rust-1.64.0-i686-unknown-linux-gnu.tar.xz",
+                    "sha256": "b22e0efcdff9bcb27aef82148f26a5d3d67da618da3e6e8c9402fe7fcdd8ca69",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -82,8 +82,8 @@
                 {
                     "type": "archive",
                     "dest": "rust-src",
-                    "url": "https://static.rust-lang.org/dist/2022-08-11/rust-src-1.63.0.tar.xz",
-                    "sha256": "d4f84d50ea61630df493db5cb1f71e7429f4118e7dbf6af5eb548910abac517d",
+                    "url": "https://static.rust-lang.org/dist/2022-09-22/rust-src-1.64.0.tar.xz",
+                    "sha256": "0d16b1af409123627a16b4101421efb5792a866e32d7a0d04781fd1169754938",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust-src",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-01-30/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "ca1fbd67a5efd558abebe8559264f8b1bd4f420647b844bc3bd247fa0f5d549e",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-02-06/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "2a612017c6fd8d7f79d86e3f2f021e58b5ba3a544b913ea02541f5bf9524a0cc",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-01-30/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "1fcb29c29be15cb17a38a83693a957bb8e704421e5a0b97599521402019b86bc",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-02-06/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "9d9f93603887bbd7a7a23d8d8add4699ae025286ffae301e881a44b393f1156f",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-03-06/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "7d7f36149507eb084edf15f303a55885d881dff3e333857dca94c03052bbc222",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-03-13/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "e0e11de9f3b2b76590b9f08f4fadb06583ab308d50be595bc11cff908c939276",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-03-06/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "c6e89504c91b354b97ef2426729b8cda69082b901d9b22bd2679908a264abcce",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-03-13/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "d3803e4fe86f633b3eed5610e9cc6283ab058dd7ca24eb5e0e952338dd9e1f77",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -120,7 +120,7 @@
                 }
             },
             "build-commands": [
-                "cd \"rust-$NATIVE_TARGET\" && ./install.sh --prefix=/usr/lib/sdk/rust-stable --without=rust-docs --disable-ldconfig --verbose",
+                "cd \"rust-$NATIVE_TARGET\" && ./install.sh --prefix=/usr/lib/sdk/rust-stable --without=rust-docs --without=rust-docs-json-preview --disable-ldconfig --verbose",
                 "test -n \"$COMPAT_TARGET\" &&  cd \"rust-$COMPAT_TARGET\" && ./install.sh --prefix=/usr/lib/sdk/rust-stable --disable-ldconfig --verbose --components=rust-std-$COMPAT_TARGET,rust-analysis-$COMPAT_TARGET",
                 "cd rust-src && ./install.sh --prefix=/usr/lib/sdk/rust-stable --disable-ldconfig --verbose"
             ]

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -27,8 +27,8 @@
                         "aarch64"
                     ],
                     "dest": "rust-armv7-unknown-linux-gnueabihf",
-                    "url": "https://static.rust-lang.org/dist/2022-09-22/rust-1.64.0-armv7-unknown-linux-gnueabihf.tar.xz",
-                    "sha256": "cad59223ac104dfb3f1ede0efb59f7212f2186da06b5d408cdfaf4710e2b9637",
+                    "url": "https://static.rust-lang.org/dist/2022-11-03/rust-1.65.0-armv7-unknown-linux-gnueabihf.tar.xz",
+                    "sha256": "c34e277f6883e0038633175b55d0af858a1f8d329c65d83fa00d125edb063352",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -41,8 +41,8 @@
                         "aarch64"
                     ],
                     "dest": "rust-aarch64-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2022-09-22/rust-1.64.0-aarch64-unknown-linux-gnu.tar.xz",
-                    "sha256": "9081928cced6fc650eaccb88f2ea154dc95c066957b234fa9c0cbe1770479f54",
+                    "url": "https://static.rust-lang.org/dist/2022-11-03/rust-1.65.0-aarch64-unknown-linux-gnu.tar.xz",
+                    "sha256": "b3a83a9585b8c4ede4eab2a11b3f96895f676d8b46c9642140c4fefd5c309ed1",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -55,8 +55,8 @@
                         "x86_64"
                     ],
                     "dest": "rust-x86_64-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2022-09-22/rust-1.64.0-x86_64-unknown-linux-gnu.tar.xz",
-                    "sha256": "bd69e42f6cfe3ba96d781ad0b4095ddac4f0fc31c1af445018edf6f0aba543e4",
+                    "url": "https://static.rust-lang.org/dist/2022-11-03/rust-1.65.0-x86_64-unknown-linux-gnu.tar.xz",
+                    "sha256": "9455cab767f7b9f46259aac8d953f15f11b3d65513384e2b0a5e77d0432ae82f",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -71,8 +71,8 @@
                         "x86_64"
                     ],
                     "dest": "rust-i686-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2022-09-22/rust-1.64.0-i686-unknown-linux-gnu.tar.xz",
-                    "sha256": "b22e0efcdff9bcb27aef82148f26a5d3d67da618da3e6e8c9402fe7fcdd8ca69",
+                    "url": "https://static.rust-lang.org/dist/2022-11-03/rust-1.65.0-i686-unknown-linux-gnu.tar.xz",
+                    "sha256": "50595b96f98e0940bbfe00209d6c233e9158e140ecd6088ad3bd53f89b123e9d",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -82,8 +82,8 @@
                 {
                     "type": "archive",
                     "dest": "rust-src",
-                    "url": "https://static.rust-lang.org/dist/2022-09-22/rust-src-1.64.0.tar.xz",
-                    "sha256": "0d16b1af409123627a16b4101421efb5792a866e32d7a0d04781fd1169754938",
+                    "url": "https://static.rust-lang.org/dist/2022-11-03/rust-src-1.65.0.tar.xz",
+                    "sha256": "7dfdbecad68d9fbc64574eb403aa4815adef563dd6fb1d8a1be3b9fff364deb2",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust-src",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -27,8 +27,8 @@
                         "aarch64"
                     ],
                     "dest": "rust-armv7-unknown-linux-gnueabihf",
-                    "url": "https://static.rust-lang.org/dist/2022-04-07/rust-1.60.0-armv7-unknown-linux-gnueabihf.tar.xz",
-                    "sha256": "f3c372bbb8927be77913dc7f3d1b4bacfdd0776008d617280dd8d046fe37846c",
+                    "url": "https://static.rust-lang.org/dist/2022-08-11/rust-1.63.0-armv7-unknown-linux-gnueabihf.tar.xz",
+                    "sha256": "81e9e3dc569047f2a26512609978a4e5d4c06a05a071d44a6d9aadb4d7cbc079",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -41,8 +41,8 @@
                         "aarch64"
                     ],
                     "dest": "rust-aarch64-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2022-04-07/rust-1.60.0-aarch64-unknown-linux-gnu.tar.xz",
-                    "sha256": "5d18bc384273edbd8a4b6d18104685651fb42d5f07bdf518ef2ec3641269c95d",
+                    "url": "https://static.rust-lang.org/dist/2022-08-11/rust-1.63.0-aarch64-unknown-linux-gnu.tar.xz",
+                    "sha256": "963dd3c8b0b1ba970e8608b5bf457c24d5dc471d68f40e5cb62582fbd0461988",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -55,8 +55,8 @@
                         "x86_64"
                     ],
                     "dest": "rust-x86_64-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2022-04-07/rust-1.60.0-x86_64-unknown-linux-gnu.tar.xz",
-                    "sha256": "83c3fb8645379ec308192fa713df87044892639495722077e07aa779b310239e",
+                    "url": "https://static.rust-lang.org/dist/2022-08-11/rust-1.63.0-x86_64-unknown-linux-gnu.tar.xz",
+                    "sha256": "be9b25bcf1e564876762e653688e0b5df11fab53048ac18bf77761cf0a0cc465",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -71,8 +71,8 @@
                         "x86_64"
                     ],
                     "dest": "rust-i686-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2022-04-07/rust-1.60.0-i686-unknown-linux-gnu.tar.xz",
-                    "sha256": "94567ff691b46ef3dff64f3866445a278a17b20639e62cdc4b6fcd7aed86cec8",
+                    "url": "https://static.rust-lang.org/dist/2022-08-11/rust-1.63.0-i686-unknown-linux-gnu.tar.xz",
+                    "sha256": "17081489b7efeb3936ed9bee2d21deaa86d76c3fed9be9e582c4325ca6aafae8",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -82,8 +82,8 @@
                 {
                     "type": "archive",
                     "dest": "rust-src",
-                    "url": "https://static.rust-lang.org/dist/2022-04-07/rust-src-1.60.0.tar.xz",
-                    "sha256": "66a96ff728d1538b1313322a754bf5b50bbfd0c3c75c6a5504c9e906918cbcb1",
+                    "url": "https://static.rust-lang.org/dist/2022-08-11/rust-src-1.63.0.tar.xz",
+                    "sha256": "d4f84d50ea61630df493db5cb1f71e7429f4118e7dbf6af5eb548910abac517d",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust-src",
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-04-18/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "7b52449d1dcdb4fb1b0f1586347a7b4fd31ad9c99a53d84e680cdf673d135979",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-09-05/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "28dcd5840675afd4c32a978d2f2ec5c3847410d63a40e944a5aebd6afcc1fa59",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-04-18/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "7c4ed45a18f8b61cb7d5d091df281704f19d7ce29c0add29d1f2f46b34f83ded",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-09-05/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "2b3fd39b08c96807ca9131dac30b4b3dc3ae6bdad1b219810fbade97891eb97e",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-01-02/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "1739d91858e924c9681a7583893c595e2f078f23803996ddfb4b9f924f88a051",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-01-09/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "2d6baf57929d677c895f0703d8401fe251b2b1cf929d02729160de35e4c71d6f",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-01-02/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "caa546120973bfbe1650c7e60b562d60aedd9939972665374a70547ea2e8344d",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-01-09/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "ffe1e03b60feabc1b53d0f16ba29c80835f2a586a23d4c0d828bf03eb40fb0e4",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-03-20/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "0bcbf744a72ac95241085280ad3b3a3cfd0939c2de8fc0d26753f666249626a4",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-03-27/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "d0d4e48a1fadd76fc7f0594d551cdc9659e6445e51c5ef6ecd8cd84331554979",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-03-20/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "cc96b03b669eb8b10d59d5d0d81afdec81c2b817fe7f1b1a6175fd08ad4a20b8",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-03-27/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "61bc21dc0b4629ce65a673fd880feb720683a9aedd4b53d832b5bd5a9d6b34e1",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -174,8 +174,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.10.0/mold-1.10.0-x86_64-linux.tar.gz",
-                    "sha256": "b1d97a63700a290b3ab4cbc8e1c705b36d7f148967648681f053bb8c319190a0",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.10.1/mold-1.10.1-x86_64-linux.tar.gz",
+                    "sha256": "7524fe67f917d5287b2f7a7d6401e2625fa3f5f84bc6b8d9b487d6cb08876488",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 241732,
@@ -189,8 +189,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.10.0/mold-1.10.0-aarch64-linux.tar.gz",
-                    "sha256": "71698d4835a9fa2815d88f4d92e66657a53cc1b9006c7bc80e960eb292885279",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.10.1/mold-1.10.1-aarch64-linux.tar.gz",
+                    "sha256": "5ad793bce5c40c2fc5c8afb77188fd504cedd2a3160baee04091bd294385305b",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 241732,

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -174,8 +174,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.4.2/mold-1.4.2-x86_64-linux.tar.gz",
-                    "sha256": "584768879ef75e57c1a129ae159f9ef65bed565d510e09fc7d9d98bc58b3d534",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.5.0/mold-1.5.0-x86_64-linux.tar.gz",
+                    "sha256": "dfbd60793f7ffb2dde5ea475744ca3c6e0a467a33d5706eb17ce115637727486",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 241732,
@@ -189,8 +189,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.4.2/mold-1.4.2-aarch64-linux.tar.gz",
-                    "sha256": "04ae35bb1d2120c901ba7887b33808081252c9e8997c90ba6ace8152ffaf28d6",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.5.0/mold-1.5.0-aarch64-linux.tar.gz",
+                    "sha256": "03e080ed8cd1e56977391a4e15c84d75d8420558f8b4e7a75354e363b9b98424",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 241732,

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-04-17/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "333f842be45447a787cba5d89b2cb112c9e4628364ffdba6d24981b70a998a94",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-04-24/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "04980e43ceef99f7e16393a43fb1f4044809e4b0847e025ec8859cd47c73f6fc",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-04-17/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "d71e25289f1b3609c97e4ef2aa12214cf4969f7802260df21069e6bf8420ce00",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-04-24/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "eb89b24661352e80ffb0dcdb0461848dc14cc88dfbc5d314200aaa380e6c5bc2",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-09-19/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "5347c331c4d2d43f6791c44c0ee7f7e4a5852146304e487f64865a40a866f1e5",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-09-26/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "1a92fa7cfa20611087924fb32b5c722a8076d82ada73943909c259d1a9360a72",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-09-19/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "095d024a0351eaf26bcea931d1145cbd95ef934048235e2812fdedfc717c87a3",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-09-26/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "59027b0e38b3e091419e70538dafffd03265b9d5b76c1255c3f119660af8ffbf",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-12-19/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "3b4fed379bd86ceabbc9b6762ce6610bf0e803fced62eacd031ac871bd47cc6c",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-12-26/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "a02548023aecc66f5c6e6309ef29b2d22f2095af3a15cf9d2491c4fc289dae84",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-12-19/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "28fb14245c5985e0410dcc7202ae592c4b0aec9de883a910aed304d43bcd13ba",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-12-26/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "3b18a90dd715d94e81dd622046db4a2d94e5691f6edf67160aa8ddef4708197f",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -174,8 +174,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.6.0/mold-1.6.0-x86_64-linux.tar.gz",
-                    "sha256": "d43b2215018f1c2280fcd64c891c570754c0322e817d75a80f9cd149b077a930",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.7.0/mold-1.7.0-x86_64-linux.tar.gz",
+                    "sha256": "113f0db9915054f558a4e41cf6dbc45b7fd45076a4064830112fac8f82091fd9",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 241732,
@@ -189,8 +189,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.6.0/mold-1.6.0-aarch64-linux.tar.gz",
-                    "sha256": "5897ac0289dce8bcd62b067900e19f29af118b1aa2f8ce7cbcc0ffb256a6c88a",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.7.0/mold-1.7.0-aarch64-linux.tar.gz",
+                    "sha256": "bb6ec2ec25f2c4b03bb1e66b303673e2203431115e1b907da9a528c64b49e65f",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 241732,

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -27,8 +27,8 @@
                         "aarch64"
                     ],
                     "dest": "rust-armv7-unknown-linux-gnueabihf",
-                    "url": "https://static.rust-lang.org/dist/2023-02-09/rust-1.67.1-armv7-unknown-linux-gnueabihf.tar.xz",
-                    "sha256": "d05c97b72b236a8dcddcb6f4ddfb7c8a49ad627a3038a8f7b4952085e246b29f",
+                    "url": "https://static.rust-lang.org/dist/2023-03-09/rust-1.68.0-armv7-unknown-linux-gnueabihf.tar.xz",
+                    "sha256": "61b4131b65ebe428802236071374d1efa374c7fa038e1795f17fd70fb057fba8",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -41,8 +41,8 @@
                         "aarch64"
                     ],
                     "dest": "rust-aarch64-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2023-02-09/rust-1.67.1-aarch64-unknown-linux-gnu.tar.xz",
-                    "sha256": "b7b8e8b70cae457092661894efa5a4861ef4f0e20f2f617d05d6f17b1f780a68",
+                    "url": "https://static.rust-lang.org/dist/2023-03-09/rust-1.68.0-aarch64-unknown-linux-gnu.tar.xz",
+                    "sha256": "79cb5c840e44d0e3623335e59c2849dd73e0048fc6f97f2d351e88b0bd85040a",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -55,8 +55,8 @@
                         "x86_64"
                     ],
                     "dest": "rust-x86_64-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2023-02-09/rust-1.67.1-x86_64-unknown-linux-gnu.tar.xz",
-                    "sha256": "7dbb718bdb09adad7e36b9a413e571863913682495527f7f2d6507ea2c068542",
+                    "url": "https://static.rust-lang.org/dist/2023-03-09/rust-1.68.0-x86_64-unknown-linux-gnu.tar.xz",
+                    "sha256": "183d53f7488095550788fe38eff80542d68e6bd92ee48442d2ce0bd60a7eceaf",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -71,8 +71,8 @@
                         "x86_64"
                     ],
                     "dest": "rust-i686-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2023-02-09/rust-1.67.1-i686-unknown-linux-gnu.tar.xz",
-                    "sha256": "b686a2d0d1648e1b84def715dd65a85a3d2802b33ecf65808bdb2ed639aec7d3",
+                    "url": "https://static.rust-lang.org/dist/2023-03-09/rust-1.68.0-i686-unknown-linux-gnu.tar.xz",
+                    "sha256": "650b7cd7a13e4739de39e7e89c534600cfb33afdc6d7774b87ed64e5b7cd17a3",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -82,8 +82,8 @@
                 {
                     "type": "archive",
                     "dest": "rust-src",
-                    "url": "https://static.rust-lang.org/dist/2023-02-09/rust-src-1.67.1.tar.xz",
-                    "sha256": "186502914ae332198ee8c2180676c6c49faef3559cbddcbe4db5244730e3ae3a",
+                    "url": "https://static.rust-lang.org/dist/2023-03-09/rust-src-1.68.0.tar.xz",
+                    "sha256": "55f3791caa40b3fd59dcce3f3188afc3f11d493ae34dfff3f839e76365c14914",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust-src",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -1,10 +1,10 @@
 {
     "id": "org.freedesktop.Sdk.Extension.rust-stable",
-    "branch": "22.08",
+    "branch": "23.08beta",
     "runtime": "org.freedesktop.Sdk",
     "build-extension": true,
     "sdk": "org.freedesktop.Sdk",
-    "runtime-version": "22.08",
+    "runtime-version": "23.08beta",
     "sdk-extensions": [],
     "separate-locales": false,
     "appstream-compose": false,

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -27,8 +27,8 @@
                         "aarch64"
                     ],
                     "dest": "rust-armv7-unknown-linux-gnueabihf",
-                    "url": "https://static.rust-lang.org/dist/2023-03-28/rust-1.68.2-armv7-unknown-linux-gnueabihf.tar.xz",
-                    "sha256": "cf4c4985f8f7cf6b7a110b52de787178ccc75bf21f839ac00807968b292afa05",
+                    "url": "https://static.rust-lang.org/dist/2023-04-20/rust-1.69.0-armv7-unknown-linux-gnueabihf.tar.xz",
+                    "sha256": "d22577fab7be91aa8099c9e494be88c5e1dc45a5ab5783703a89514423bd3876",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -41,8 +41,8 @@
                         "aarch64"
                     ],
                     "dest": "rust-aarch64-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2023-03-28/rust-1.68.2-aarch64-unknown-linux-gnu.tar.xz",
-                    "sha256": "1731add9b04d0fcbd096b610a67e1b1ae5740ce1171dd904d944ff504a84bcc7",
+                    "url": "https://static.rust-lang.org/dist/2023-04-20/rust-1.69.0-aarch64-unknown-linux-gnu.tar.xz",
+                    "sha256": "1d92fc3dd807c0182d0f87b90a9d5dac8be4164d3096634e2da23cc2a6c39792",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -55,8 +55,8 @@
                         "x86_64"
                     ],
                     "dest": "rust-x86_64-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2023-03-28/rust-1.68.2-x86_64-unknown-linux-gnu.tar.xz",
-                    "sha256": "7f0f19d50f32a353ca78bc5d6d7c483efeced684e2c37ff847e4fd9699c7e063",
+                    "url": "https://static.rust-lang.org/dist/2023-04-20/rust-1.69.0-x86_64-unknown-linux-gnu.tar.xz",
+                    "sha256": "fe0d3eb8604a72cd70030b72b3199a2eb7ed2a427ac7462e959e93b367ff5855",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -71,8 +71,8 @@
                         "x86_64"
                     ],
                     "dest": "rust-i686-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2023-03-28/rust-1.68.2-i686-unknown-linux-gnu.tar.xz",
-                    "sha256": "cade060a15c5064763cd67ebba418989cdbdfb1dc4b6fe8dd4310f187540f66a",
+                    "url": "https://static.rust-lang.org/dist/2023-04-20/rust-1.69.0-i686-unknown-linux-gnu.tar.xz",
+                    "sha256": "5f05309294ba144ef1dc69dff8c34405ce5ed1ee9200b6ab49540287a40f2143",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -82,8 +82,8 @@
                 {
                     "type": "archive",
                     "dest": "rust-src",
-                    "url": "https://static.rust-lang.org/dist/2023-03-28/rust-src-1.68.2.tar.xz",
-                    "sha256": "a13264dde47c267e73b0fd3751cab109c1bda53d15a2d9ea9fbfe5dc35085552",
+                    "url": "https://static.rust-lang.org/dist/2023-04-20/rust-src-1.69.0.tar.xz",
+                    "sha256": "286abeaec3caba40c07d801d7474c6c522a358eb0618225c9265e136a601f4dc",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust-src",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-04-10/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "432934089bf6217a31d844061a791c39215e38ef84b790e8c3c94cfaa9d3af09",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-04-17/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "333f842be45447a787cba5d89b2cb112c9e4628364ffdba6d24981b70a998a94",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-04-10/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "c26ee171adabe9e66fd17a33be792bcc912c56ced864102cc5dda2d227e0c7ca",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-04-17/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "d71e25289f1b3609c97e4ef2aa12214cf4969f7802260df21069e6bf8420ce00",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-12-12/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "625b1282c41dd192c63b269a4455cb9e2305fa831dd7195ab81fd1fcadc28caf",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-12-19/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "3b4fed379bd86ceabbc9b6762ce6610bf0e803fced62eacd031ac871bd47cc6c",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-12-12/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "5d741017dfa47bce76141fd9e96f66c1e2d6969abeccb62855e4af3950df8678",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-12-19/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "28fb14245c5985e0410dcc7202ae592c4b0aec9de883a910aed304d43bcd13ba",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -27,8 +27,8 @@
                         "aarch64"
                     ],
                     "dest": "rust-armv7-unknown-linux-gnueabihf",
-                    "url": "https://static.rust-lang.org/dist/2023-03-23/rust-1.68.1-armv7-unknown-linux-gnueabihf.tar.xz",
-                    "sha256": "6ba1691daea0d7497ccf7ce9c988762121f2639a8dd48de3c3b4a0173069da62",
+                    "url": "https://static.rust-lang.org/dist/2023-03-28/rust-1.68.2-armv7-unknown-linux-gnueabihf.tar.xz",
+                    "sha256": "cf4c4985f8f7cf6b7a110b52de787178ccc75bf21f839ac00807968b292afa05",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -41,8 +41,8 @@
                         "aarch64"
                     ],
                     "dest": "rust-aarch64-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2023-03-23/rust-1.68.1-aarch64-unknown-linux-gnu.tar.xz",
-                    "sha256": "1ec89e697f5e491749eb534540f8adb7f315e63916ccc1c59a38a9349b59b1bd",
+                    "url": "https://static.rust-lang.org/dist/2023-03-28/rust-1.68.2-aarch64-unknown-linux-gnu.tar.xz",
+                    "sha256": "1731add9b04d0fcbd096b610a67e1b1ae5740ce1171dd904d944ff504a84bcc7",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -55,8 +55,8 @@
                         "x86_64"
                     ],
                     "dest": "rust-x86_64-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2023-03-23/rust-1.68.1-x86_64-unknown-linux-gnu.tar.xz",
-                    "sha256": "a6f954e908675e20819cce5e0fc9e13da0b932e2a5c554b2fb14745188d8ef42",
+                    "url": "https://static.rust-lang.org/dist/2023-03-28/rust-1.68.2-x86_64-unknown-linux-gnu.tar.xz",
+                    "sha256": "7f0f19d50f32a353ca78bc5d6d7c483efeced684e2c37ff847e4fd9699c7e063",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -71,8 +71,8 @@
                         "x86_64"
                     ],
                     "dest": "rust-i686-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2023-03-23/rust-1.68.1-i686-unknown-linux-gnu.tar.xz",
-                    "sha256": "ba9da610b317e9b5cd6bf8ba06738d5c58c33555531548f17dc8ec2911e24f21",
+                    "url": "https://static.rust-lang.org/dist/2023-03-28/rust-1.68.2-i686-unknown-linux-gnu.tar.xz",
+                    "sha256": "cade060a15c5064763cd67ebba418989cdbdfb1dc4b6fe8dd4310f187540f66a",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -82,8 +82,8 @@
                 {
                     "type": "archive",
                     "dest": "rust-src",
-                    "url": "https://static.rust-lang.org/dist/2023-03-23/rust-src-1.68.1.tar.xz",
-                    "sha256": "891921684825736d57e105c1c80af2dce3580913109a4c9caefb3a1d9e751fa8",
+                    "url": "https://static.rust-lang.org/dist/2023-03-28/rust-src-1.68.2.tar.xz",
+                    "sha256": "a13264dde47c267e73b0fd3751cab109c1bda53d15a2d9ea9fbfe5dc35085552",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust-src",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-04-04/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "f0871bc6b1ac5af42dd00d8beffa34aaa7d611f357f1a91b9b0be454bbcf5af3",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-04-10/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "432934089bf6217a31d844061a791c39215e38ef84b790e8c3c94cfaa9d3af09",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-04-04/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "616ed047f099b6b190427c57bf0f1a0a3ec2571d2b0eb8b1f52db687e3e39080",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-04-10/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "c26ee171adabe9e66fd17a33be792bcc912c56ced864102cc5dda2d227e0c7ca",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -27,8 +27,8 @@
                         "aarch64"
                     ],
                     "dest": "rust-armv7-unknown-linux-gnueabihf",
-                    "url": "https://static.rust-lang.org/dist/2023-01-10/rust-1.66.1-armv7-unknown-linux-gnueabihf.tar.xz",
-                    "sha256": "4aeff6472c44e5a8756b63c493dbb3820739dc80f5e9e62dd509f32cd5a724c8",
+                    "url": "https://static.rust-lang.org/dist/2023-01-26/rust-1.67.0-armv7-unknown-linux-gnueabihf.tar.xz",
+                    "sha256": "65e1dcac8154181532179d6dd28a3ec19baea875c38556437cf5fae72281531e",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -41,8 +41,8 @@
                         "aarch64"
                     ],
                     "dest": "rust-aarch64-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2023-01-10/rust-1.66.1-aarch64-unknown-linux-gnu.tar.xz",
-                    "sha256": "a1279760f91b3571733e0b0268128d143be2734916753900b5fe7b8ecc3c0900",
+                    "url": "https://static.rust-lang.org/dist/2023-01-26/rust-1.67.0-aarch64-unknown-linux-gnu.tar.xz",
+                    "sha256": "5a108891cab3fd0567bf8c2b44f18c045c067c607bbec3ea62b02ad40809b151",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -55,8 +55,8 @@
                         "x86_64"
                     ],
                     "dest": "rust-x86_64-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2023-01-10/rust-1.66.1-x86_64-unknown-linux-gnu.tar.xz",
-                    "sha256": "a201aa4595ec8015662b7103b1409a4787c6d1f1d540bb68746633527d855858",
+                    "url": "https://static.rust-lang.org/dist/2023-01-26/rust-1.67.0-x86_64-unknown-linux-gnu.tar.xz",
+                    "sha256": "e6345aebeba55f39cb35fc06a3ac6c43c35f596309a6ed26023b1898346419bd",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -71,8 +71,8 @@
                         "x86_64"
                     ],
                     "dest": "rust-i686-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2023-01-10/rust-1.66.1-i686-unknown-linux-gnu.tar.xz",
-                    "sha256": "835b4e1b4d396674f7866a83b9a4f44db16fd12f01a7eaed527282b3700a9b92",
+                    "url": "https://static.rust-lang.org/dist/2023-01-26/rust-1.67.0-i686-unknown-linux-gnu.tar.xz",
+                    "sha256": "2ba12fe020b17de3a6fe7633c59ab50ef44f9715caa858077aad3301408f583c",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -82,8 +82,8 @@
                 {
                     "type": "archive",
                     "dest": "rust-src",
-                    "url": "https://static.rust-lang.org/dist/2023-01-10/rust-src-1.66.1.tar.xz",
-                    "sha256": "752aa6cb02db94dc246cdcef4186f4e1d1640b72a7954b9cda01f479a7d1ed76",
+                    "url": "https://static.rust-lang.org/dist/2023-01-26/rust-src-1.67.0.tar.xz",
+                    "sha256": "4b8cc00fb5ea48aec48ae31ef09376d76e1ffa034f07d938fa56653bdc6d0875",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust-src",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-09-05/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "28dcd5840675afd4c32a978d2f2ec5c3847410d63a40e944a5aebd6afcc1fa59",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-09-12/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "7cffcc22557ede856096a3e4021b4f83176dd6b3ac4e222e330268707d98a3bd",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-09-05/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "2b3fd39b08c96807ca9131dac30b4b3dc3ae6bdad1b219810fbade97891eb97e",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-09-12/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "1b3857080b4d0d5c713540c802fdd166286480dea4efc67d9f135b56fd63995a",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-10-17/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "323cad202e161c4e4b9bc7669552fd9c6e55b2368cccf2c0d61ef86e8caf7dc9",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-10-24/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "7b5f8eaed7770a2e38564872cd92a9c23e24e170c123c39a84b09477130a2892",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-10-17/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "d4c5c1a6df116a27f548ed17ffb57594f97713cde323c932cf7ba9d88dc9c21a",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-10-24/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "1e81ff975eab14cea247e9f77e88ecf44760789f49da46d1e9745fefc70893d8",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -174,8 +174,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.7.1/mold-1.7.1-x86_64-linux.tar.gz",
-                    "sha256": "66b38b8ab3143f23c1eaad598dd9055ce84f39729f92d63eddbd856a73d65784",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.8.0/mold-1.8.0-x86_64-linux.tar.gz",
+                    "sha256": "308b8a3c8a44e232348a13764f581538ec80c28c420167fd6dad3d64c05e17c2",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 241732,
@@ -189,8 +189,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.7.1/mold-1.7.1-aarch64-linux.tar.gz",
-                    "sha256": "9c43875c00972c61196eac41fca297403ec24c36b9232d1a6aa1cb84ce40f829",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.8.0/mold-1.8.0-aarch64-linux.tar.gz",
+                    "sha256": "b9464df5f3dd36e17f473173afcd853f1cc2c357e52ec2b896950283c2a2adfd",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 241732,

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-12-26/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "a02548023aecc66f5c6e6309ef29b2d22f2095af3a15cf9d2491c4fc289dae84",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-01-02/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "1739d91858e924c9681a7583893c595e2f078f23803996ddfb4b9f924f88a051",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-12-26/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "3b18a90dd715d94e81dd622046db4a2d94e5691f6edf67160aa8ddef4708197f",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-01-02/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "caa546120973bfbe1650c7e60b562d60aedd9939972665374a70547ea2e8344d",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -134,8 +134,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-11-07/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "319b445878208c6eb02a0c6167c7591bc2ed64fe018d9d962e24567ba1f11fab",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-11-14/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "540dbcd6e9840105c70ed1d629c2e5822dc494c7387c7db51f1e5704b75c5d23",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -149,8 +149,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-11-07/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "a584dd5682d3ffb10c59b1421cddd8a74e7bc2372aea492c4a383e2bad4389fa",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2022-11-14/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "0f40bcd2527314e1332c45a96cff3c7f06f8e2b5f6e5e388bc307bbc64555c0e",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -174,8 +174,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.5.0/mold-1.5.0-x86_64-linux.tar.gz",
-                    "sha256": "dfbd60793f7ffb2dde5ea475744ca3c6e0a467a33d5706eb17ce115637727486",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.5.1/mold-1.5.1-x86_64-linux.tar.gz",
+                    "sha256": "2b4006aa3935bd65e448e0d0f0e70fe57c4d9a12074435e69bc31b212fdaa160",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 241732,
@@ -189,8 +189,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rui314/mold/releases/download/v1.5.0/mold-1.5.0-aarch64-linux.tar.gz",
-                    "sha256": "03e080ed8cd1e56977391a4e15c84d75d8420558f8b4e7a75354e363b9b98424",
+                    "url": "https://github.com/rui314/mold/releases/download/v1.5.1/mold-1.5.1-aarch64-linux.tar.gz",
+                    "sha256": "d71e728a6e2d0b6f58536ddd97f8592552d060b0cb9920a23b7db79c11efb26b",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 241732,


### PR DESCRIPTION
- Update to 22.08 runtime
- Update 6 modules
- mold: Correct f-e-d-c URL template
- Update mold-linux.tar.gz to 1.4.2
- Update rust-analyzer-linux.gz to 2022-09-12
- Update rust-analyzer-linux.gz to 2022-09-19
- Update 5 modules
- Update rust-analyzer-linux.gz to 2022-09-26
- Update mold-linux.tar.gz to 1.5.0
- Update mold-linux.tar.gz to 1.5.1
- Update rust-analyzer-linux.gz to 2022-10-03
- Update rust-analyzer-linux.gz to 2022-10-10
- Update rust-analyzer-linux.gz to 2022-10-17
- Update mold-linux.tar.gz to 1.6.0
- Update rust-analyzer-linux.gz to 2022-10-24
- Update rust-analyzer-linux.gz to 2022-10-31
- Update 5 modules
- Update rust-analyzer-linux.gz to 2022-11-07
- Update rust-analyzer-linux.gz to 2022-11-14
- Update mold-linux.tar.gz to 1.7.0
- Update mold-linux.tar.gz to 1.7.1
- Update rust-analyzer-linux.gz to 2022-11-21
- Update rust-analyzer-linux.gz to 2022-11-28
- Update rust-analyzer-linux.gz to 2022-12-05
- Update rust-analyzer-linux.gz to 2022-12-12
- Update 5 modules
- Fix build due to upstream changes
- Update rust-analyzer-linux.gz to 2022-12-19
- Update rust-analyzer-linux.gz to 2022-12-26
- Update mold-linux.tar.gz to 1.8.0
- Update rust-analyzer-linux.gz to 2023-01-02
- Update rust-analyzer-linux.gz to 2023-01-09
- Update mold-linux.tar.gz to 1.9.0
- Update sha of rust-analyzer
- Update 5 modules
- Update rust-analyzer-linux.gz to 2023-01-16
- Update mold-linux.tar.gz to 1.10.0
- Update rust-analyzer-linux.gz to 2023-01-23
- Update mold-linux.tar.gz to 1.10.1
- Update 5 modules
- Update rust-analyzer-linux.gz to 2023-01-30
- Update rust-analyzer-linux.gz to 2023-02-06
- Update 5 modules
- Update rust-analyzer-linux.gz to 2023-02-13
- Update rust-analyzer-linux.gz to 2023-02-20
- Update rust-analyzer-linux.gz to 2023-02-27
- Update rust-analyzer-linux.gz to 2023-03-06
- Update 5 modules
- Update rust-analyzer-linux.gz to 2023-03-13
- Update mold-linux.tar.gz to 1.11.0
- Update rust-analyzer-linux.gz to 2023-03-20
- Update 5 modules
- Update rust-analyzer-linux.gz to 2023-03-27
- Update 5 modules
- Update rust-analyzer-linux.gz to 2023-04-03
- Update rust-analyzer-linux.gz to 2023-04-04
- Update rust-analyzer-linux.gz to 2023-04-10
- Update rust-analyzer-linux.gz to 2023-04-17
- Update 5 modules
- Update rust-analyzer-linux.gz to 2023-04-24
- Update to 23.08beta
