### PR TITLE
Allow to use mold with GCC

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,27 +2,73 @@
 
 This extension contains various components of the [Rust](https://www.rust-lang.org) stable toolchain.
 
+To be able to use the Rust binaries at build time, add the following to your Flatpak manifest:
+
+```json
+{
+    "sdk-extensions": [
+        "org.freedesktop.Sdk.Extension.rust-stable"
+    ],
+    "build-options": {
+        "append-path": "/usr/lib/sdk/rust-stable/bin",
+    }
+}
+```
 
 ## Mold
 
-In order to use the (fast) [`mold`](https://github.com/rui314/mold) linker:
+This extension bundles also the (fast) [`mold`](https://github.com/rui314/mold) linker, which can be
+used to improve linking time.
 
-1. Add `org.freedesktop.Sdk.Extension.llvm16` along with this extension in order to get `clang`.
-2. Add `/usr/lib/sdk/llvm16/bin` to `append-path`. See [llvm16 SDK extension readme](https://github.com/flathub/org.freedesktop.Sdk.Extension.llvm16) for more information.
-3. Set environment variables:
-    - `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER` to `clang`, and
-    - `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS` to `-C link-arg=-fuse-ld=/usr/lib/sdk/rust-stable/bin/mold`.
+### With gcc
 
-In total, the changed parts of your flatpak manifest should look like this:
+1. Add this extension.
+2. Set the `RUSTFLAGS` environment variable to `-C link-arg=-fuse-ld=mold`.
+
+In total, the changed parts of your Flatpak manifest should look like this:
+
+```json
+{
+    "sdk-extensions": [
+        "org.freedesktop.Sdk.Extension.rust-stable"
+    ],
+    "build-options": {
+        "append-path": "/usr/lib/sdk/rust-stable/bin",
+        "env": {
+            "RUSTFLAGS": "-C link-arg=-fuse-ld=mold"
+        }
+    }
+}
+```
+
+### With clang
+
+1. Add this extension.
+2. Add a version of the [`org.freedesktop.Sdk.Extension.llvm{version}`](https://github.com/flathub?q=org.freedesktop.Sdk.Extension.llvm)
+   extension compatible with the `runtime` in your Flatpak manifest.
+   
+   For example, if your runtime is based on the `org.freedesktop.Platform//25.08` runtime, you can
+   use the [llvm20](https://github.com/flathub/org.freedesktop.Sdk.Extension.llvm20)
+   or [llvm21](https://github.com/flathub/org.freedesktop.Sdk.Extension.llvm21) extensions.
+   
+   See the README of the chosen extension for more information.
+4. Set the following environment variables for each target triple that you want to build:
+    - `CARGO_TARGET_{TARGET_TRIPLE}_LINKER` to `clang`, and
+    - `CARGO_TARGET_{TARGET_TRIPLE}_RUSTFLAGS` to `-C link-arg=-fuse-ld=/usr/lib/sdk/rust-stable/bin/mold`.
+    
+    The `TARGET_TRIPLE`s supported by Flathub are `X86_64_UNKNOWN_LINUX_GNU` and
+    `AARCH64_UNKNOWN_LINUX_GNU`.
+
+In total, the changed parts of your Flatpak manifest should look like this:
 
 ```json
 {
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.rust-stable",
-        "org.freedesktop.Sdk.Extension.llvm16"
+        "org.freedesktop.Sdk.Extension.llvm21"
     ],
     "build-options": {
-        "append-path": "/usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/llvm16/bin",
+        "append-path": "/usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/llvm21/bin",
         "env": {
             "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER": "clang",
             "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS": "-C link-arg=-fuse-ld=/usr/lib/sdk/rust-stable/bin/mold",
@@ -33,9 +79,6 @@ In total, the changed parts of your flatpak manifest should look like this:
 }
 ```
 
-Note: `llvm16` is needed until there is a release of `gcc12.1`.
-As soon as `gcc12.1` is in the freedesktop sdk, `gcc` can be used instead of `clang`.
-
 ## Debugging/Development
 
 In order to use this extension in flatpak SDK environment you may add all provided tools in your PATH by executing first:
@@ -43,4 +86,4 @@ In order to use this extension in flatpak SDK environment you may add all provid
 source /usr/lib/sdk/rust-stable/enable.sh
 ```
 
-You can also combine this extension with `lldb` using the LLVM SDK extension. See the extension's [readme](https://github.com/flathub/org.freedesktop.Sdk.Extension.llvm13) for more information.
+You can also combine this extension with `lldb` using the LLVM SDK extension. See the extension's [readme](https://github.com/flathub/org.freedesktop.Sdk.Extension.llvm20) for more information.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ In total, the changed parts of your Flatpak manifest should look like this:
 ### With clang
 
 1. Add this extension.
-2. Add a version of the [`org.freedesktop.Sdk.Extension.llvm{version}`](https://github.com/flathub?q=org.freedesktop.Sdk.Extension.llvm)
+2. Add an [`org.freedesktop.Sdk.Extension.llvm{version}`](https://github.com/flathub?q=org.freedesktop.Sdk.Extension.llvm)
    extension compatible with the `runtime` in your Flatpak manifest.
    
    For example, if your runtime is based on the `org.freedesktop.Platform//25.08` runtime, you can
@@ -86,4 +86,6 @@ In order to use this extension in flatpak SDK environment you may add all provid
 source /usr/lib/sdk/rust-stable/enable.sh
 ```
 
-You can also combine this extension with `lldb` using the LLVM SDK extension. See the extension's [readme](https://github.com/flathub/org.freedesktop.Sdk.Extension.llvm20) for more information.
+You can also combine this extension with `lldb` using an [`org.freedesktop.Sdk.Extension.llvm{version}`](https://github.com/flathub?q=org.freedesktop.Sdk.Extension.llvm)
+extension compatible with the `runtime` in your Flatpak manifest. See the README of the chosen
+extension for more information.

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -202,7 +202,9 @@
             "buildsystem": "simple",
             "build-commands": [
                 "install -m 755 bin/mold /usr/lib/sdk/rust-stable/bin/mold",
-                "install -m 755 bin/ld.mold /usr/lib/sdk/rust-stable/bin/ld.mold"
+                "install -m 755 bin/ld.mold /usr/lib/sdk/rust-stable/bin/ld.mold",
+                "mkdir -p /usr/lib/sdk/rust-stable/share/licenses/mold/",
+                "install -m 755 share/doc/mold/LICENSE /usr/lib/sdk/rust-stable/share/licenses/mold/LICENSE"
             ]
         },
         {

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -201,7 +201,8 @@
             ],
             "buildsystem": "simple",
             "build-commands": [
-                "install -m 755 bin/mold /usr/lib/sdk/rust-stable/bin/mold"
+                "install -m 755 bin/mold /usr/lib/sdk/rust-stable/bin/mold",
+                "install -m 755 bin/ld.mold /usr/lib/sdk/rust-stable/bin/ld.mold"
             ]
         },
         {


### PR DESCRIPTION
It seems that the only part missing for GCC to be able to use mold is the `ld.mold` symlink that is provided in the archive, so I changed the command to copy the content of `bin`. I tested this change locally successfully.

I also updated the README to use GCC since it's simpler and it doesn't need to be kept up to date.

Fixes #168.