### PR TITLE
Bump rust-bindgen to v0.72.1

### DIFF
--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -303,8 +303,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/rust-lang/rust-bindgen/",
-                    "commit": "af7fd38d5e80514406fb6a8bba2d407d252c30b9",
-                    "tag": "v0.71.1"
+                    "commit": "d874de8d646d9b8a3e7ba2db2bcd52f2fba8f1f5",
+                    "tag": "v0.72.1"
                 },
                 "./rust-bindgen.json"
             ],


### PR DESCRIPTION
We need at least Bindgen 0.72.0 for our mixed C/Rust project to build properly so I decided to open a PR here to get things updated.

The cargo dependences are unchanged between these versions, so the only change here is updating the version that is pulled from Git.

I can also open additional PRs for other branches if that makes things easier, feel free to let me know if you need any changes / improvements :)
