### PR TITLE
beta: Update rust to 1.98

### DIFF
--- a/org.freedesktop.Sdk.Extension.rust-stable.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.rust-stable.appdata.xml
@@ -13,8 +13,11 @@
   <url type="homepage">https://github.com/flathub/org.freedesktop.Sdk.Extension.rust-stable/</url>
   <update_contact>danigm@gnome.org</update_contact>
   <releases>
-    <release version="1.97.1" date="2026-07-16">
+    <release version="1.98.0" date="2026-08-20">
       <description></description>
+    </release>
+    <release version="1.97.1" date="2026-07-16">
+      <description/>
     </release>
     <release version="1.97.0" date="2026-07-09">
       <description/>

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -216,8 +216,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/lu-zero/cargo-c/releases/download/v0.10.24/cargo-c-x86_64-unknown-linux-musl.tar.gz",
-                    "sha256": "503a6de066897b810051f2944e4157629c580d0e36219cddb39ad45116d0e8f5",
+                    "url": "https://github.com/lu-zero/cargo-c/releases/download/v0.10.25/cargo-c-x86_64-unknown-linux-musl.tar.gz",
+                    "sha256": "2fbf0d1b56a9a0b52431c2a159d9544b4b0729f2eabaed3904a41cce0e8cd4b0",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/lu-zero/cargo-c/releases/latest",
@@ -232,8 +232,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/lu-zero/cargo-c/releases/download/v0.10.24/cargo-c-aarch64-unknown-linux-musl.tar.gz",
-                    "sha256": "d1fac5dbecdc5f4c833e815d6d1717cdb762799e15ccfd122b08e5955a138394",
+                    "url": "https://github.com/lu-zero/cargo-c/releases/download/v0.10.25/cargo-c-aarch64-unknown-linux-musl.tar.gz",
+                    "sha256": "8df4475f48d7dc4d6a7fcd60bf96d569e5dabc24dce98a4a189419822c594257",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/lu-zero/cargo-c/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -133,8 +133,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2026-08-17.4/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "a559eaa29920e4c12718fba101f2055f1da0ad8bc458ef9dc1a670778cc66901",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2026-08-24/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "c4d409690b98d84ce98174829362a59214825d72304fe2504f4b906a116b51fe",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -148,8 +148,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2026-08-17.4/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "941ad31c4256eec3c8457257b0fcfb696d2b4f80c0e5a996f7375a92130c2447",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2026-08-24/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "3463f9115c725fc5dfb002431833ec83d1f1f9c4c35b76ad5f47b92c58a521f1",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",

--- a/org.freedesktop.Sdk.Extension.rust-stable.json
+++ b/org.freedesktop.Sdk.Extension.rust-stable.json
@@ -26,8 +26,8 @@
                         "aarch64"
                     ],
                     "dest": "rust-armv7-unknown-linux-gnueabihf",
-                    "url": "https://static.rust-lang.org/dist/2026-07-16/rust-1.97.1-armv7-unknown-linux-gnueabihf.tar.xz",
-                    "sha256": "3bc49061509d76d023e8d6a0aee5c9c62f700173e6e87ba3059021fdb0ecb571",
+                    "url": "https://static.rust-lang.org/dist/2026-08-20/rust-1.98.0-armv7-unknown-linux-gnueabihf.tar.xz",
+                    "sha256": "db104aaff49fedb1b64b661b0cd30df64054341fc629612c92b7701858016618",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -40,8 +40,8 @@
                         "aarch64"
                     ],
                     "dest": "rust-aarch64-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2026-07-16/rust-1.97.1-aarch64-unknown-linux-gnu.tar.xz",
-                    "sha256": "9a7a2c336b4787f1b72f6bab7c35d5b7af2fd03cbd39b4fc721466a70d402a7d",
+                    "url": "https://static.rust-lang.org/dist/2026-08-20/rust-1.98.0-aarch64-unknown-linux-gnu.tar.xz",
+                    "sha256": "ac9283184301aeed06ecc9f5aa4c1be7041e18a1b197b6cb6c5d162d98f566da",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -54,8 +54,8 @@
                         "x86_64"
                     ],
                     "dest": "rust-x86_64-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2026-07-16/rust-1.97.1-x86_64-unknown-linux-gnu.tar.xz",
-                    "sha256": "88f28fa9af20594179f85d6df67078dfd6fa93e2f6da5e1e9b0ac4997988ca4f",
+                    "url": "https://static.rust-lang.org/dist/2026-08-20/rust-1.98.0-x86_64-unknown-linux-gnu.tar.xz",
+                    "sha256": "ed8ee2df70909c88cbaf87a6cfa3920dac00b537de12a6abe6906641e0f5952f",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -70,8 +70,8 @@
                         "x86_64"
                     ],
                     "dest": "rust-i686-unknown-linux-gnu",
-                    "url": "https://static.rust-lang.org/dist/2026-07-16/rust-1.97.1-i686-unknown-linux-gnu.tar.xz",
-                    "sha256": "1687b56e6e7585dea809ab7b82d93f35417f3760a76c3d0d7f6dec252ff1751b",
+                    "url": "https://static.rust-lang.org/dist/2026-08-20/rust-1.98.0-i686-unknown-linux-gnu.tar.xz",
+                    "sha256": "1e4aeb1122f8f4ce8cb1c1544ac7a87acbf6cbc28da0144c8e728810e737ef1d",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust",
@@ -81,8 +81,8 @@
                 {
                     "type": "archive",
                     "dest": "rust-src",
-                    "url": "https://static.rust-lang.org/dist/2026-07-16/rust-src-1.97.1.tar.xz",
-                    "sha256": "e9a1e616d04c6845895c827a178b9227f7c7199f3f4a80af81ab3aff7b80156b",
+                    "url": "https://static.rust-lang.org/dist/2026-08-20/rust-src-1.98.0.tar.xz",
+                    "sha256": "0e977492aed5ff137815bf9b4b796e8a85b80fb2367ed64e82d5c5839870f2bf",
                     "x-checker-data": {
                         "type": "rust",
                         "package": "rust-src",
@@ -133,8 +133,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2026-08-10.1/rust-analyzer-x86_64-unknown-linux-gnu.gz",
-                    "sha256": "d42908a7dc7b89250ae881a0919e477296843665c98574ecc8fe16ba60cecefb",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2026-08-17.4/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                    "sha256": "a559eaa29920e4c12718fba101f2055f1da0ad8bc458ef9dc1a670778cc66901",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",
@@ -148,8 +148,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2026-08-10.1/rust-analyzer-aarch64-unknown-linux-gnu.gz",
-                    "sha256": "a7eb3a97865dd189ad4fff526fbe73559bece876fdbd641e0f50f39271043542",
+                    "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2026-08-17.4/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                    "sha256": "941ad31c4256eec3c8457257b0fcfb696d2b4f80c0e5a996f7375a92130c2447",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rust-analyzer/rust-analyzer/releases/latest",


### PR DESCRIPTION
Backports from branch/25.08.